### PR TITLE
Renable ProjectCache and project purging

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
@@ -210,6 +210,13 @@ public class ApplicationBeansConfiguration {
     }
 
     @Bean
+    ProjectCacheManager projectCacheManager(ProjectCache projectCache,
+                                            ApplicationDisposablesManager disposablesManager) {
+        var cacheManager = new ProjectCacheManager(projectCache, disposablesManager);
+        return cacheManager;
+    }
+
+    @Bean
     @Singleton
     ProjectCache getProjectCache(ProjectComponentFactory projectComponentFactory) {
         return new ProjectCache(projectComponentFactory,

--- a/src/main/java/edu/stanford/protege/webprotege/index/impl/IndexUpdater.java
+++ b/src/main/java/edu/stanford/protege/webprotege/index/impl/IndexUpdater.java
@@ -141,8 +141,9 @@ public class IndexUpdater {
                             @Nonnull UpdatableIndex index,
                             @Nonnull ImmutableList<ImmutableList<OntologyChange>> revisions,
                             @Nonnull CountDownLatch countDownLatch) {
+        // Just run Task in this thread, for now
         var updaterTask = new IndexUpdaterTask(projectId, rank, index, revisions, countDownLatch);
-        indexUpdaterService.submit(updaterTask);
+        updaterTask.run();
     }
 
     public synchronized void updateIndexes(ImmutableList<OntologyChange> changes) {

--- a/src/main/java/edu/stanford/protege/webprotege/project/ProjectCache.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/ProjectCache.java
@@ -101,6 +101,7 @@ public class ProjectCache implements HasDispose {
      * Purges projects that have not been access for some given period of time
      */
     public void purgeDormantProjects() {
+        logger.info("Starting sweep to purge dormant projects.  There are {} projects currently in total.", projectId2ProjectComponent.size());
         // No locking needed
         for (ProjectId projectId : getCachedProjectIds()) {
             long time = getLastAccessTime(projectId);
@@ -180,6 +181,7 @@ public class ProjectCache implements HasDispose {
 
     public void purge(ProjectId projectId) {
         try {
+            logger.info("Purging project: {}", projectId);
             writeLock.lock();
             lastAccessLock.writeLock().lock();
             var projectComponent = projectId2ProjectComponent.remove(projectId);


### PR DESCRIPTION
This functionality was disabled/broken since the shift from Dagger to Spring Dependency Injection.  This functionality is essential for a heavily trafficked installation with lots of relatively small to medium sized projects.