### PR TITLE
CRITICAL FIX.  Fix duplicates in ProjectOntologiesIndexImpl

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/index/impl/ProjectOntologiesIndexImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/index/impl/ProjectOntologiesIndexImpl.java
@@ -68,7 +68,7 @@ public class ProjectOntologiesIndexImpl implements ProjectOntologiesIndex, Updat
                 ontologyIds.remove(ontologyChange.ontologyId());
             }
         }
-        cache = ImmutableList.copyOf(ontologyIds);
+        cache = ImmutableList.copyOf(ontologyIds.elementSet());
         initialized = true;
     }
 }


### PR DESCRIPTION
The cache of ontology ids was filled with the multiset rather than strict set.