### PR TITLE
fixed remove forms on error.

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/forms/EntityFormRepositoryImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/forms/EntityFormRepositoryImpl.java
@@ -10,6 +10,8 @@ import com.mongodb.client.model.Indexes;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import javax.annotation.*;
@@ -53,6 +55,8 @@ public class EntityFormRepositoryImpl implements EntityFormRepository {
     private final Lock readLock = readWriteLock.readLock();
 
     private final Lock writeLock = readWriteLock.writeLock();
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(EntityFormRepositoryImpl.class);
 
     @Inject
     public EntityFormRepositoryImpl(ObjectMapper objectMapper, MongoTemplate database) {
@@ -131,17 +135,22 @@ public class EntityFormRepositoryImpl implements EntityFormRepository {
         try {
             writeLock.lock();
             var collection = getCollection();
-            collection.deleteMany(new Document(PROJECT_ID, projectId.id()));
+            var docs = new ArrayList<Document>();
+
             if (!formDescriptors.isEmpty()) {
-                var docs = new ArrayList<Document>();
                 for (int ordinal = 0; ordinal < formDescriptors.size(); ordinal++) {
                     var formDescriptor = formDescriptors.get(ordinal);
                     var record = FormDescriptorRecord.get(projectId, formDescriptor, ordinal);
                     var recordDocument = objectMapper.convertValue(record, Document.class);
                     docs.add(recordDocument);
                 }
+            }
+            collection.deleteMany(new Document(PROJECT_ID, projectId.id()));
+            if (!docs.isEmpty()) {
                 collection.insertMany(docs);
             }
+        }catch (Exception e) {
+            LOGGER.error("Error saving forms for project " + projectId.id(), e);
         } finally {
             writeLock.unlock();
         }

--- a/src/test/java/edu/stanford/protege/webprotege/project/CreateProjectSagaManagerTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/project/CreateProjectSagaManagerTest.java
@@ -103,7 +103,7 @@ class CreateProjectSagaManagerTest {
                                                         "en",
                                                         "TheProjectDescription");
         manager.execute(newProjectSettings, executionContext);
-        Thread.sleep(300);
+        Thread.sleep(600);
         verify(projectPermissionsInitializer, times(1)).applyDefaultPermissions(any(ProjectId.class),
                                                                                 eq(janeDoe));
     }


### PR DESCRIPTION
when saving the forms, if the mapping from object to document was failing , the forms were deleted with nothing replacing them. Changed the order of operations so this won't happen anymore.