### PR TITLE
Fixed flaky test shouldGetClsAsRootEntity in SubjectClosureResolver_TestCase.java

### DIFF
--- a/src/test/java/edu/stanford/protege/webprotege/entity/SubjectClosureResolver_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/entity/SubjectClosureResolver_TestCase.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -68,7 +69,7 @@ public class SubjectClosureResolver_TestCase {
         when(axiom.getSubject()).thenReturn(clsIri);
         var rootEntities = resolver.resolve(valueEntity)
                 .collect(toSet());
-        assertThat(rootEntities, contains(cls, valueEntity));
+        assertThat(rootEntities, hasItems(cls, valueEntity));
     }
 
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changing the assertion from contains() to hasItems() in the testcase : `shouldGetClsAsRootEntity` in class `SubjectClosureResolver_TestCase`.

### Why are the changes needed?
Multiple flaky tests were detected in the above testcase while trying to run the tests using the nondex tool. [NonDex](https://github.com/TestingResearchIllinois/NonDex) is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. 

#### Steps to reproduce flakiness using nondex -
```
mvn install

mvn test -Dtest=edu.stanford.protege.webprotege.entity.SubjectClosureResolver_TestCase#shouldGetClsAsRootEntity

mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=edu.stanford.protege.webprotege.entity.SubjectClosureResolver_TestCase#shouldGetClsAsRootEntity
```

#### ERROR logs: 
 

```
[ERROR]   SubjectClosureResolver_TestCase.shouldGetClsAsRootEntity:71 
Expected: iterable containing [<<http://example.org/Cls>>, <<http://example.org/Other>>]
     but: item 0: was <<http://example.org/Other>>
[INFO] 
```

<img width="1069" alt="Screenshot 2024-11-09 at 3 04 16 PM" src="https://github.com/user-attachments/assets/02ac8aad-e688-4ad4-aa8e-a8082cc52a88">

### Reason for Failure 

The method `shouldGetClsAsRootEntity` uses toSet() method which has no guarantee of order. 

<img width="1352" alt="Screenshot 2024-11-09 at 3 06 29 PM" src="https://github.com/user-attachments/assets/d89cd533-3b07-497e-89b4-2b651c6e475a">

The `contains()` method also checks the order of the entities which are being compared. It checks for the order of the two objects cls and valueEntity as well. This can lead to failure of test case when valueEntity comes after cls. Hence the proposed change is to use method hasItems() which checks if the entities are present in the set or not, irrespective of the order.

Please let me know if you have any questions or would like to discuss this further for any clarificaitions. 