### PR TITLE
added correlation ids on calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>webprotege-ipc</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/edu/stanford/protege/webprotege/dispatch/RequestContext.java
+++ b/src/main/java/edu/stanford/protege/webprotege/dispatch/RequestContext.java
@@ -17,17 +17,6 @@ public class RequestContext {
 
     private final ExecutionContext executionContext;
 
-    /**
-     * Constructs a {@link RequestContext} for the user specified by {@code userId}.
-     *
-     * @param userId The {@link UserId}.  Not {@code null}.
-     * @throws NullPointerException if {@code userId} is {@code null}.
-     */
-    public RequestContext(UserId userId) {
-        this.userId = checkNotNull(userId, "userId must not be null");
-        this.executionContext = new ExecutionContext(userId, null);
-    }
-
     public RequestContext(UserId userId, ExecutionContext executionContext) {
         this.userId = checkNotNull(userId, "userId must not be null");
         this.executionContext = executionContext;

--- a/src/main/java/edu/stanford/protege/webprotege/permissions/GetProjectPermissionsActionHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/permissions/GetProjectPermissionsActionHandler.java
@@ -50,7 +50,7 @@ public class GetProjectPermissionsActionHandler implements ApplicationActionHand
         Set<Capability> capabilities = accessManager.getCapabilityClosure(
                 forUser(executionContext.userId()),
                 forProject(action.projectId()),
-                new ExecutionContext(executionContext.userId(), executionContext.jwt()));
+                new ExecutionContext(executionContext.userId(), executionContext.jwt(), executionContext.correlationId()));
         return new GetProjectPermissionsResult(ImmutableSet.copyOf(capabilities));
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/permissions/ProjectPermissionsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/permissions/ProjectPermissionsManagerImpl.java
@@ -36,7 +36,7 @@ public class ProjectPermissionsManagerImpl implements ProjectPermissionsManager 
     @Override
     public List<ProjectDetails> getReadableProjects(ExecutionContext executionContext) {
         Set<ProjectDetails> result = new HashSet<>();
-        accessManager.getResourcesAccessibleToSubject(forUser(executionContext.userId()), VIEW_PROJECT.getCapability(), new ExecutionContext(executionContext.userId(), executionContext.jwt()))
+        accessManager.getResourcesAccessibleToSubject(forUser(executionContext.userId()), VIEW_PROJECT.getCapability(), new ExecutionContext(executionContext.userId(), executionContext.jwt(), executionContext.correlationId()))
                      .stream()
                      .filter(Resource::isProject)
                      .forEach(

--- a/src/main/java/edu/stanford/protege/webprotege/project/GetAvailableProjectsWithPermissionActionHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/GetAvailableProjectsWithPermissionActionHandler.java
@@ -54,7 +54,7 @@ public class GetAvailableProjectsWithPermissionActionHandler implements Applicat
                                                             @Nonnull ExecutionContext executionContext) {
         var userId = Subject.forUser(executionContext.userId());
         var permission = action.getPermission();
-        var projectDetails = accessManager.getResourcesAccessibleToSubject(userId, permission, new edu.stanford.protege.webprotege.ipc.ExecutionContext(executionContext.userId(), executionContext.jwt()))
+        var projectDetails = accessManager.getResourcesAccessibleToSubject(userId, permission, new edu.stanford.protege.webprotege.ipc.ExecutionContext(executionContext.userId(), executionContext.jwt(), executionContext.correlationId()))
                      .stream()
                      .map(Resource::getProjectId)
                      .filter(Optional::isPresent)

--- a/src/main/java/edu/stanford/protege/webprotege/project/GetAvailableProjectsWithPermissionCommandHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/GetAvailableProjectsWithPermissionCommandHandler.java
@@ -33,7 +33,7 @@ public class GetAvailableProjectsWithPermissionCommandHandler implements Command
     @Override
     public Mono<GetAvailableProjectsWithPermissionResult> handleRequest(GetAvailableProjectsWithPermissionAction request,
                                                                         edu.stanford.protege.webprotege.ipc.ExecutionContext executionContext) {
-        var result = delegate.execute(request, new ExecutionContext(executionContext.userId(), executionContext.jwt()));
+        var result = delegate.execute(request, new ExecutionContext(executionContext.userId(), executionContext.jwt(), executionContext.correlationId()));
         return Mono.just(result);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/user/GetAuthenticatedUserDetailsActionHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/GetAuthenticatedUserDetailsActionHandler.java
@@ -58,7 +58,7 @@ public class GetAuthenticatedUserDetailsActionHandler implements ApplicationActi
                                                 .orElse(UserDetails.getUserDetails(userId,
                                                                                    userId.id(), Optional.empty()));
             var permittedActions = accessManager.getCapabilityClosure(Subject.forUser(userId), ApplicationResource.get(),
-                    new edu.stanford.protege.webprotege.ipc.ExecutionContext(executionContext.userId(), executionContext.jwt()));
+                    new edu.stanford.protege.webprotege.ipc.ExecutionContext(executionContext.userId(), executionContext.jwt(), executionContext.correlationId()));
             return new GetAuthenticatedUserDetailsResponse(userDetails, permittedActions);
         }
     }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{correlationId}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- If you're using a file appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/webprotege-backend-service.log</file>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{correlationId}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/webprotege-backend.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/src/test/java/edu/stanford/protege/webprotege/admin/GetApplicationPreferencesActionHandler_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/admin/GetApplicationPreferencesActionHandler_TestCase.java
@@ -48,7 +48,7 @@ public class GetApplicationPreferencesActionHandler_TestCase {
 
     private UserId userId = edu.stanford.protege.webprotege.MockingUtils.mockUserId();
 
-    private ExecutionContext executionContext = new ExecutionContext(userId, "DUMMY_JWT");
+    private ExecutionContext executionContext = new ExecutionContext(userId, "DUMMY_JWT", "correlationId");
 
     private RequestContext requestContext = new RequestContext(userId, executionContext);
 

--- a/src/test/java/edu/stanford/protege/webprotege/dispatch/ExecutionContext_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/dispatch/ExecutionContext_TestCase.java
@@ -30,7 +30,7 @@ public class ExecutionContext_TestCase {
 
     @BeforeEach
     public void setUp() throws Exception {
-        context = new ExecutionContext(userId, "");
+        context = new ExecutionContext(userId, "", "correlationId");
     }
 
     @Test

--- a/src/test/java/edu/stanford/protege/webprotege/dispatch/impl/DispatchServiceExecutorImpl_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/dispatch/impl/DispatchServiceExecutorImpl_TestCase.java
@@ -37,7 +37,7 @@ public class DispatchServiceExecutorImpl_TestCase<A extends Action<R>, R extends
     @Mock
     private RequestContext requestContext;
 
-    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT");
+    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT", "correlationId");
 
 
     @Mock

--- a/src/test/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyDescriptorActionHandlerTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyDescriptorActionHandlerTest.java
@@ -61,7 +61,7 @@ class GetHierarchyDescriptorActionHandlerTest {
         );
         request = new GetHierarchyDescriptorRequest(projectId, displayContext);
 
-        executionContext = new ExecutionContext(UserId.valueOf("user1"), "dummy-jwt-token");
+        executionContext = new ExecutionContext(UserId.valueOf("user1"), "dummy-jwt-token", "correlationId");
     }
 
     @Test

--- a/src/test/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyDescriptorCommandHandlerTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyDescriptorCommandHandlerTest.java
@@ -57,7 +57,7 @@ class GetHierarchyDescriptorCommandHandlerTest {
         );
         request = new GetHierarchyDescriptorRequest(projectId, displayContext);
 
-        executionContext = new ExecutionContext(UserId.valueOf("user1"), "dummy-jwt-token");
+        executionContext = new ExecutionContext(UserId.valueOf("user1"), "dummy-jwt-token", "correlationId");
 
         expectedResponse = new GetHierarchyDescriptorResponse(ClassHierarchyDescriptor.create());
     }

--- a/src/test/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyDescriptorRulesCommandHandlerTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyDescriptorRulesCommandHandlerTest.java
@@ -39,7 +39,7 @@ class GetHierarchyDescriptorRulesCommandHandlerTest {
         var projectId = ProjectId.generate();
         request = new GetProjectHierarchyDescriptorRulesRequest(projectId);
 
-        executionContext = new ExecutionContext(UserId.valueOf("123e4567-e89b-12d3-a456-426614174999"), "dummy-jwt-token");
+        executionContext = new ExecutionContext(UserId.valueOf("123e4567-e89b-12d3-a456-426614174999"), "dummy-jwt-token", "correlationId");
 
         expectedResponse = new GetProjectHierarchyDescriptorRulesResponse(List.of());
     }

--- a/src/test/java/edu/stanford/protege/webprotege/merge/OntologyPatcher_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/merge/OntologyPatcher_TestCase.java
@@ -66,7 +66,7 @@ public class OntologyPatcher_TestCase {
                                       ontologyDiff2OntologyChanges);
         when(ontologyDiff2OntologyChanges.getOntologyChangesFromDiff(ontologyDiff))
                 .thenReturn(ImmutableList.of(ontologyChange));
-        executionContext = new ExecutionContext(userId, "DUMMY_JWT");
+        executionContext = new ExecutionContext(userId, "DUMMY_JWT", "correlationId");
     }
 
     @Test

--- a/src/test/java/edu/stanford/protege/webprotege/project/CreateProjectSagaManagerTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/project/CreateProjectSagaManagerTest.java
@@ -76,7 +76,7 @@ class CreateProjectSagaManagerTest {
                                                revisionHistoryReplacer,
                                                projectPermissionsInitializer);
         janeDoe = UserId.valueOf("JaneDoe");
-        executionContext = new ExecutionContext(janeDoe, "");
+        executionContext = new ExecutionContext(janeDoe, "", "correlationId");
         newProjectSettings = NewProjectSettings.get(janeDoe,
                                                     "TheProjectDisplayName",
                                                     "en",

--- a/src/test/java/edu/stanford/protege/webprotege/project/GetProjectDetailsActionHandler_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/project/GetProjectDetailsActionHandler_TestCase.java
@@ -40,7 +40,7 @@ public class GetProjectDetailsActionHandler_TestCase {
     @Mock
     private ProjectDetails projectDetails;
 
-    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT");
+    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT", "correlationId");
 
 
     @BeforeEach

--- a/src/test/java/edu/stanford/protege/webprotege/projectsettings/GetProjectSettingsActionHandler_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/projectsettings/GetProjectSettingsActionHandler_TestCase.java
@@ -42,7 +42,7 @@ public class GetProjectSettingsActionHandler_TestCase {
     @Mock
     private GetProjectSettingsAction action;
 
-    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT");
+    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT", "correlationId");
 
 
     @Mock

--- a/src/test/java/edu/stanford/protege/webprotege/revision/GetHeadRevisionNumberActionHandler_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/revision/GetHeadRevisionNumberActionHandler_TestCase.java
@@ -28,7 +28,7 @@ public class GetHeadRevisionNumberActionHandler_TestCase {
 
     private GetHeadRevisionNumberAction action = new GetHeadRevisionNumberAction(ProjectId.generate());
 
-    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT");
+    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT", "correlationId");
 
     @Mock
     private RevisionNumber revisionNumber;

--- a/src/test/java/edu/stanford/protege/webprotege/user/GetUserIdCompletionsActionHandler_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/user/GetUserIdCompletionsActionHandler_TestCase.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 public class GetUserIdCompletionsActionHandler_TestCase {
 
     private GetUserIdCompletionsActionHandler actionHandler;
-    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT");
+    private ExecutionContext executionContext = new ExecutionContext(new UserId("1"), "DUMMY_JWT", "correlationId");
 
     @Mock
     private UserDetailsManager userDetailsManager;


### PR DESCRIPTION
Due to ipc bump ,we propagate the correlation id via execution context to all subsequent calls.