### PR TITLE
Fix merge-additions routing and naming

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddAction.java
@@ -13,10 +13,10 @@ import java.util.List;
 
 @AutoValue
 
-@JsonTypeName("ExistingOntologyMergeAdd")
+@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
 public abstract class ExistingOntologyMergeAddAction implements ProjectAction<ExistingOntologyMergeAddResult> {
 
-    public static final String CHANNEL = "webprotege.ontologies.MergeExistingOntology";
+    public static final String CHANNEL = "webprotege.ontologies.ExistingOntologyMergeAdd";
 
     @JsonCreator
     public static ExistingOntologyMergeAddAction create(@JsonProperty("projectId") ProjectId projectId,

--- a/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddCommandHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddCommandHandler.java
@@ -1,0 +1,34 @@
+package edu.stanford.protege.webprotege.merge_add;
+
+import edu.stanford.protege.webprotege.api.ActionExecutor;
+import edu.stanford.protege.webprotege.ipc.CommandHandler;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import edu.stanford.protege.webprotege.ipc.WebProtegeHandler;
+import javax.annotation.Nonnull;
+import reactor.core.publisher.Mono;
+
+@WebProtegeHandler
+public class ExistingOntologyMergeAddCommandHandler implements CommandHandler<ExistingOntologyMergeAddAction, ExistingOntologyMergeAddResult> {
+
+    private final ActionExecutor executor;
+
+    public ExistingOntologyMergeAddCommandHandler(ActionExecutor executor) {
+        this.executor = executor;
+    }
+
+    @Nonnull
+    @Override
+    public String getChannelName() {
+        return ExistingOntologyMergeAddAction.CHANNEL;
+    }
+
+    @Override
+    public Class<ExistingOntologyMergeAddAction> getRequestClass() {
+        return ExistingOntologyMergeAddAction.class;
+    }
+
+    @Override
+    public Mono<ExistingOntologyMergeAddResult> handleRequest(ExistingOntologyMergeAddAction request, ExecutionContext executionContext) {
+        return executor.executeRequest(request, executionContext);
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddResult.java
@@ -7,7 +7,7 @@ import edu.stanford.protege.webprotege.dispatch.Result;
 
 @AutoValue
 
-@JsonTypeName("ExistingOntologyMergeAdd")
+@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
 public class ExistingOntologyMergeAddResult implements Result {
 
     @JsonCreator

--- a/src/main/java/edu/stanford/protege/webprotege/merge_add/MergeOntologiesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge_add/MergeOntologiesAction.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @AutoValue
 
-@JsonTypeName("MergeOntologies")
+@JsonTypeName("webprotege.ontologies.MergeOntologies")
 public abstract class MergeOntologiesAction implements ProjectAction<MergeOntologiesResult> {
 
     public static final String CHANNEL = "webprotege.ontologies.MergeOntologies";

--- a/src/main/java/edu/stanford/protege/webprotege/merge_add/MergeOntologiesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge_add/MergeOntologiesResult.java
@@ -8,7 +8,7 @@ import edu.stanford.protege.webprotege.dispatch.Result;
 
 @AutoValue
 
-@JsonTypeName("MergeOntologies")
+@JsonTypeName("webprotege.ontologies.MergeOntologies")
 public abstract class MergeOntologiesResult implements Result {
 
     @JsonCreator


### PR DESCRIPTION
The "merge additions" actions and the message bus disagreed on their names, so requests were routed to the wrong handler — or to no handler at all.

This makes each action's JSON type name and channel consistent and matching the client and backend-api:

- Merge into a new ontology → `webprotege.ontologies.MergeOntologies`
- Merge into an existing ontology → `webprotege.ontologies.ExistingOntologyMergeAdd`

It also adds the missing command handler for the "merge into an existing ontology" request, which previously had no listener on its channel.