### PR TITLE
fix(build): keep classpath resources in the packaged jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,26 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <!-- The compile phase wipes target/classes before recompiling (a
+                         maven-compiler-plugin behaviour triggered by the annotation
+                         processors Dagger/AutoValue/AutoFactory), which deletes the
+                         resources that the standard process-resources step copied there
+                         (application.properties, builtin-perspective-data/*.json,
+                         logback-spring.xml, built-in-prefixes.csv). They then never make it
+                         into the jar. Re-copy resources after compilation, before packaging. -->
+                    <execution>
+                        <id>copy-resources-after-compile</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>


### PR DESCRIPTION
## Problem

The service jar — and therefore the released Docker image — was built **without its classpath resources**: `application.properties`, `builtin-perspective-data/*.json`, `logback-spring.xml`, `built-in-prefixes.csv`. Only compiled classes ended up in `BOOT-INF/classes/`. This caused two runtime failures:

- **Startup config**: with `application.properties` absent, Spring could not resolve `webprotege.rabbitmq.*` / `webprotege.minio.*` placeholders, so the context aborted (`Could not resolve placeholder 'webprotege.rabbitmq.responsequeue'`) unless every value was supplied externally.
- **Empty perspectives**: `BuiltInPerspectiveLoader` loads `builtin-perspective-data/<name>.json` from the classpath. With those files missing, `GetPerspectives` returned an empty list and newly created projects opened with no layout.

## Root cause

The `compile` phase wipes `target/classes` before recompiling — a `maven-compiler-plugin` behaviour triggered by the annotation processors (Dagger / AutoValue / AutoFactory). Since `process-resources` copies resources into `target/classes` *before* `compile`, they get deleted, and the jar is then packaged with compiled classes only. Verified step-by-step:

- after `process-resources`: `target/classes` contains the 8 perspective files
- after `compile`: 0

`<useIncrementalCompilation>false</useIncrementalCompilation>` does **not** prevent the wipe in maven-compiler-plugin 3.13.0.

## Fix

Re-run the `resources` goal in the `prepare-package` phase (after `compile`, before `package`) so the resources are restored into `target/classes` before the jar is assembled.

## Verification

The rebuilt jar/image now contains all resources (8 perspectives + `application.properties` + `logback-spring.xml` + `built-in-prefixes.csv`), backend-service starts with no placeholder errors, and projects open with their perspectives.
