### PR TITLE
Fix SetProjectSettings deserialization: read/write the settings field the client actually uses

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsAction.java
@@ -36,7 +36,7 @@ public class SetProjectSettingsAction implements ProjectAction<SetProjectSetting
     }
 
     @JsonCreator
-    public static SetProjectSettingsAction create(@JsonProperty("projectSettings") ProjectSettings projectSettings) {
+    public static SetProjectSettingsAction create(@JsonProperty("settings") ProjectSettings projectSettings) {
         return new SetProjectSettingsAction(projectSettings);
     }
 

--- a/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.projectsettings;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -29,6 +30,7 @@ public class SetProjectSettingsResult implements Result {
         return new SetProjectSettingsResult(projectSettings);
     }
 
+    @JsonProperty("settings")
     public ProjectSettings getProjectSettings() {
         return projectSettings;
     }


### PR DESCRIPTION
## What this fixes

Saving project settings (e.g. renaming a project's display name) failed every time with a 400 from the api gateway, and the real cause never surfaced to the user or the logs in an obvious way.

`SetProjectSettingsAction`/`SetProjectSettingsResult` still read/wrote a JSON field called `projectSettings`. The client (`webprotege-gwt-ui`) was conformed at some point to send `changeRequestId`, `projectId`, and `settings` as top-level fields instead — so Jackson passed `null` for the field this class's `@JsonCreator` expected, its constructor's `checkNotNull` threw, and that surfaced as an opaque 400.

## Fix

Rename the `@JsonProperty` the `create()` factory binds from `"projectSettings"` to `"settings"`, and add the matching `@JsonProperty("settings")` to the result's getter so the response the client reads back uses the same key it expects. No field/getter renames, no channel/behavior changes elsewhere — a wire-shape fix only.

## Test plan

- `mvn package` (full reactor, tests included): passing.
- Verified live end-to-end against the e2e stack in `webprotege-gwt-ui`: rebuilt this service with the fix, renamed a project's display name through the UI, and confirmed the rename now persists and survives a reload — previously reproduced this exact 400 on the current published `5.0.8` image.
