### PR TITLE
Never let saving sharing settings remove the acting user's own access

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManager.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManager.java
@@ -1,6 +1,9 @@
 package edu.stanford.protege.webprotege.sharing;
 
 import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+
+import javax.annotation.Nonnull;
 
 /**
  * Matthew Horridge
@@ -9,7 +12,15 @@ import edu.stanford.protege.webprotege.common.ProjectId;
  */
 public interface ProjectSharingSettingsManager {
 
-    void setProjectSharingSettings(ProjectSharingSettings projectSharingSettings);
+    /**
+     * @param actingUserId The user making this change. Implementations must
+     *                     not leave this user without the access they had
+     *                     before the call, even if their entry in
+     *                     {@code projectSharingSettings} (if present) fails
+     *                     to resolve - otherwise a user can lock themselves
+     *                     out of a project they were just editing.
+     */
+    void setProjectSharingSettings(@Nonnull UserId actingUserId, @Nonnull ProjectSharingSettings projectSharingSettings);
 
     ProjectSharingSettings getProjectSharingSettings(ProjectId projectId);
 }

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
@@ -11,6 +11,7 @@ import edu.stanford.protege.webprotege.user.UserDetailsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import jakarta.inject.Inject;
 import java.util.*;
 
@@ -61,9 +62,21 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
 
 
     @Override
-    public void setProjectSharingSettings(ProjectSharingSettings settings) {
+    public void setProjectSharingSettings(@Nonnull UserId actingUserId, @Nonnull ProjectSharingSettings settings) {
         ProjectId projectId = settings.getProjectId();
         ProjectResource projectResource = new ProjectResource(projectId);
+
+        // Capture the acting user's roles before making any changes. The
+        // person-lookup below is a best-effort, search-based existence
+        // check that can fail even for a real, currently signed-in user
+        // (transient RPC failure, timeout, indexing gaps) - if that
+        // happens for the acting user's own entry, or they are simply not
+        // included in the submitted settings, we still must not leave them
+        // without the access they had a moment ago. Losing your own access
+        // to a project you are actively editing sharing settings for is a
+        // lockout with no way back in short of direct DB intervention.
+        Collection<RoleId> actingUserRolesBeforeChange =
+                accessManager.getAssignedRoles(forUser(actingUserId), projectResource);
 
         // Remove existing assignments
         accessManager.getSubjectsWithAccessToResource(projectResource)
@@ -79,6 +92,7 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
         if(!linkSharingPermission.isPresent()) {
             accessManager.setAssignedRoles(forAnySignedInUser(), projectResource, emptySet());
         }
+        boolean actingUserRoleWasSet = false;
         for (SharingSetting setting : map.values()) {
             PersonId personId = setting.getPersonId();
             Optional<UserId> userId = userLookup.getUserByUserIdOrEmail(personId.getId());
@@ -87,12 +101,27 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
                 accessManager.setAssignedRoles(forUser(userId.get()),
                                                projectResource,
                                                roles);
+                if (userId.get().equals(actingUserId)) {
+                    actingUserRoleWasSet = true;
+                }
             }
             else {
-                logger.info("User in sharing setting not found.  An email invitation needs to be sent");
+                logger.warn("Could not resolve the user for a project sharing setting (person id '{}', " +
+                            "project {}) - their access was not updated.  An email invitation needs to " +
+                            "be sent.", personId.getId(), projectId);
                 // TODO
                 // We need to send the user an email invitation
             }
+        }
+
+        // Safety net: never let this call remove the acting user's own
+        // access. If their entry did not resolve above, or they were not
+        // part of the submitted settings at all, restore whatever access
+        // they had immediately before this call.
+        if (!actingUserRoleWasSet && !actingUserRolesBeforeChange.isEmpty()) {
+            logger.warn("Restoring user {}'s pre-existing access to project {} because the submitted " +
+                        "sharing settings would otherwise have removed it.", actingUserId, projectId);
+            accessManager.setAssignedRoles(forUser(actingUserId), projectResource, new HashSet<>(actingUserRolesBeforeChange));
         }
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/SetProjectSharingSettingsActionHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/SetProjectSharingSettingsActionHandler.java
@@ -38,7 +38,7 @@ public class SetProjectSharingSettingsActionHandler extends AbstractProjectActio
     @Nonnull
     @Override
     public SetProjectSharingSettingsResult execute(@Nonnull SetProjectSharingSettingsAction action, @Nonnull ExecutionContext executionContext) {
-        sharingSettingsManager.setProjectSharingSettings(action.settings());
+        sharingSettingsManager.setProjectSharingSettings(executionContext.userId(), action.settings());
         return new SetProjectSharingSettingsResult();
     }
 


### PR DESCRIPTION
## What this fixes

`webprotege-backend-api#65` documented a real lockout: saving the project sharing page could leave the **project owner unable to open their own project**.

`setProjectSharingSettings` unconditionally revokes every existing role assignment on the project first, then re-grants roles one entry at a time based on `userLookup.getUserByUserIdOrEmail()` — a best-effort, search-based existence check (a remote call with a 3s timeout, empty result on any exception). If that lookup fails for the acting user's own entry — which reproduces live even for a real, currently signed-in user, not just a genuinely unregistered one — their access is never re-granted, and they're locked out with no way back in short of direct database intervention.

## Fix

Capture the acting user's roles before making any changes. If the reassignment loop doesn't end up granting them a role (their entry failed to resolve, or they weren't included in the submitted settings at all), restore their prior roles instead of leaving them without access. Also promotes the per-entry lookup-failure log from INFO to WARN, since it's silently dropping data today.

**Scope note**: this does not implement the missing "email invitation for an unregistered person" flow (still a `TODO` in the same method) — sharing with a genuinely new person still won't grant them access. That's separate, larger follow-up work tracked on #65, which stays open after this merges.

## Test plan

- `mvn package` (full reactor, tests included): passing.
- Verified live end-to-end against the e2e stack in `webprotege-gwt-ui`: reproduced the exact original lockout (owner shares with a person who fails to resolve), confirmed it previously left the owner seeing "Forbidden" on their own project, and confirmed this fix keeps them in — the new warning log shows the restore path firing.
- Re-verified after rebasing onto `main` (post-#175 merge): full Playwright suite (85 tests) green.

Related to protegeproject/webprotege-backend-api#65 (partial fix — see scope note above).
