### PR TITLE
Distinguish confirmed-absent user from failed lookup

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
@@ -93,9 +93,25 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
             accessManager.setAssignedRoles(forAnySignedInUser(), projectResource, emptySet());
         }
         boolean actingUserRoleWasSet = false;
+        RuntimeException lookupFailure = null;
         for (SharingSetting setting : map.values()) {
             PersonId personId = setting.getPersonId();
-            Optional<UserId> userId = userLookup.getUserByUserIdOrEmail(personId.getId());
+            Optional<UserId> userId;
+            try {
+                userId = userLookup.getUserByUserIdOrEmail(personId.getId());
+            } catch (RuntimeException e) {
+                // The full stack trace for this exception was already logged inside the lookup
+                // itself (or, for a duplicate-match, is self-explanatory) - avoid dumping it again here.
+                logger.error("Could not look up the user for a project sharing setting (person id '{}', " +
+                             "project {}) - their access was not updated: {}",
+                             personId.getId(), projectId, e.toString());
+                if (lookupFailure == null) {
+                    lookupFailure = e;
+                } else {
+                    lookupFailure.addSuppressed(e);
+                }
+                continue;
+            }
             if (userId.isPresent()) {
                 ImmutableSet<RoleId> roles = Roles.fromSharingPermission(setting.getSharingPermission());
                 accessManager.setAssignedRoles(forUser(userId.get()),
@@ -121,7 +137,18 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
         if (!actingUserRoleWasSet && !actingUserRolesBeforeChange.isEmpty()) {
             logger.warn("Restoring user {}'s pre-existing access to project {} because the submitted " +
                         "sharing settings would otherwise have removed it.", actingUserId, projectId);
-            accessManager.setAssignedRoles(forUser(actingUserId), projectResource, new HashSet<>(actingUserRolesBeforeChange));
+            try {
+                accessManager.setAssignedRoles(forUser(actingUserId), projectResource, new HashSet<>(actingUserRolesBeforeChange));
+            } catch (RuntimeException e) {
+                if (lookupFailure != null) {
+                    e.addSuppressed(lookupFailure);
+                }
+                throw e;
+            }
+        }
+
+        if (lookupFailure != null) {
+            throw lookupFailure;
         }
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManager.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManager.java
@@ -38,8 +38,13 @@ public interface UserDetailsManager {
     /**
      * Gets a User by its user id or it's email address.
      * @param userNameOrEmail The user id or email address as a string.  Not {@code null}.
-     * @return The User.  An absent value will be returned if there is not such user with the specified id or email
-     * address. Not {@code null}.
+     * @return The User.  An absent value will be returned only if the lookup completed successfully
+     * and confirmed that there is no such user with the specified id or email address - it never
+     * means "the lookup could not be checked". Not {@code null}.
+     * @throws UserLookupException if the lookup could not be completed, for example due to a timeout
+     * or an RPC/messaging failure communicating with the remote user-query service.
+     * @throws RuntimeException if the specified id or email address matches more than one user - this
+     * indicates a data-integrity problem rather than an infrastructure failure or a confirmed absence.
      */
     Optional<UserId> getUserByUserIdOrEmail(String userNameOrEmail);
 

--- a/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManagerImpl.java
@@ -118,10 +118,10 @@ public class UserDetailsManagerImpl implements UserDetailsManager {
                                         .completions();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.error("Error fetching for userID ", e);
+            logger.error("Error fetching for userID {}", userNameOrEmail, e);
             throw new UserLookupException("Error fetching for userID " + userNameOrEmail, e);
         } catch (Exception e) {
-            logger.error("Error fetching for userID ", e);
+            logger.error("Error fetching for userID {}", userNameOrEmail, e);
             throw new UserLookupException("Error fetching for userID " + userNameOrEmail, e);
         }
         if (response == null || response.isEmpty()) {

--- a/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManagerImpl.java
@@ -111,19 +111,26 @@ public class UserDetailsManagerImpl implements UserDetailsManager {
 
     @Override
     public Optional<UserId> getUserByUserIdOrEmail(String userNameOrEmail) {
-        try{
-            List<UserId> response =  getUsersExecutor.execute(new UsersQueryRequest(userNameOrEmail), new ExecutionContext()).get(3, TimeUnit.SECONDS).completions();
-            if(response == null || response.isEmpty()) {
-                return Optional.empty();
-            }
-            if(response.size() > 1) {
-                logger.error("Duplicated user with username {}", userNameOrEmail);
-                throw new RuntimeException("Duplicated user with username " + userNameOrEmail);
-            }
-            return Optional.of(UserId.valueOf(response.get(0).id()));
+        List<UserId> response;
+        try {
+            response = getUsersExecutor.execute(new UsersQueryRequest(userNameOrEmail), new ExecutionContext())
+                                        .get(3, TimeUnit.SECONDS)
+                                        .completions();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Error fetching for userID ", e);
+            throw new UserLookupException("Error fetching for userID " + userNameOrEmail, e);
         } catch (Exception e) {
             logger.error("Error fetching for userID ", e);
+            throw new UserLookupException("Error fetching for userID " + userNameOrEmail, e);
+        }
+        if (response == null || response.isEmpty()) {
             return Optional.empty();
         }
+        if (response.size() > 1) {
+            logger.error("Duplicated user with username {}", userNameOrEmail);
+            throw new RuntimeException("Duplicated user with username " + userNameOrEmail);
+        }
+        return Optional.of(UserId.valueOf(response.get(0).id()));
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/user/UserLookupException.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/UserLookupException.java
@@ -1,0 +1,16 @@
+package edu.stanford.protege.webprotege.user;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Signals that a user lookup (by user id or email address) could not be completed due to an
+ * infrastructure failure - for example a timeout, or an RPC/messaging error communicating with
+ * the remote user-query service.  This is distinct from {@link java.util.Optional#empty()}, which
+ * signals that the lookup completed successfully and confirmed that no such user exists.
+ */
+public class UserLookupException extends RuntimeException {
+
+    public UserLookupException(@Nonnull String message, @Nonnull Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/metaproject/UserDetailsManagerImpl_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/metaproject/UserDetailsManagerImpl_TestCase.java
@@ -14,10 +14,17 @@ import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,5 +81,57 @@ public void shouldThrowNullPointerExceptionIf_Repository_IsNull() {
     public void shouldGetUserIdByEmail() {
         EmailAddress emailAddress = new EmailAddress(email);
         assertThat(userDetailsManagerImpl.getUserIdByEmailAddress(emailAddress), is(java.util.Optional.of(userId)));
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenUserIsConfirmedAbsent() throws Exception {
+        UsersQueryResponse response = new UsersQueryResponse(new ArrayList<>());
+        CompletableFuture<UsersQueryResponse> future = mock(CompletableFuture.class);
+        when(future.get(3, TimeUnit.SECONDS)).thenReturn(response);
+        when(getUsersExecutor.execute(any(), any())).thenReturn(future);
+
+        assertThat(userDetailsManagerImpl.getUserByUserIdOrEmail("unknown-user"), is(Optional.empty()));
+    }
+
+    @Test
+    public void shouldReturnUserIdWhenSingleMatchIsFound() throws Exception {
+        UsersQueryResponse response = new UsersQueryResponse(List.of(userId));
+        CompletableFuture<UsersQueryResponse> future = mock(CompletableFuture.class);
+        when(future.get(3, TimeUnit.SECONDS)).thenReturn(response);
+        when(getUsersExecutor.execute(any(), any())).thenReturn(future);
+
+        assertThat(userDetailsManagerImpl.getUserByUserIdOrEmail(userId.id()), is(Optional.of(userId)));
+    }
+
+    @Test
+    public void shouldThrowRuntimeExceptionWhenDuplicateMatchIsFound() throws Exception {
+        UserId otherUserId = edu.stanford.protege.webprotege.MockingUtils.mockUserId();
+        UsersQueryResponse response = new UsersQueryResponse(List.of(userId, otherUserId));
+        CompletableFuture<UsersQueryResponse> future = mock(CompletableFuture.class);
+        when(future.get(3, TimeUnit.SECONDS)).thenReturn(response);
+        when(getUsersExecutor.execute(any(), any())).thenReturn(future);
+
+        assertThrows(RuntimeException.class,
+                      () -> userDetailsManagerImpl.getUserByUserIdOrEmail(userId.id()));
+    }
+
+    @Test
+    public void shouldThrowUserLookupExceptionOnTimeout() throws Exception {
+        CompletableFuture<UsersQueryResponse> future = mock(CompletableFuture.class);
+        when(future.get(3, TimeUnit.SECONDS)).thenThrow(new TimeoutException("Timed out"));
+        when(getUsersExecutor.execute(any(), any())).thenReturn(future);
+
+        assertThrows(UserLookupException.class,
+                      () -> userDetailsManagerImpl.getUserByUserIdOrEmail(userId.id()));
+    }
+
+    @Test
+    public void shouldThrowUserLookupExceptionOnRpcOrMessagingFailure() throws Exception {
+        CompletableFuture<UsersQueryResponse> future = mock(CompletableFuture.class);
+        when(future.get(3, TimeUnit.SECONDS)).thenThrow(new ExecutionException(new RuntimeException("RPC failure")));
+        when(getUsersExecutor.execute(any(), any())).thenReturn(future);
+
+        assertThrows(UserLookupException.class,
+                      () -> userDetailsManagerImpl.getUserByUserIdOrEmail(userId.id()));
     }
 }

--- a/src/test/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl_TestCase.java
@@ -1,0 +1,233 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import edu.stanford.protege.webprotege.MockingUtils;
+import edu.stanford.protege.webprotege.access.AccessManager;
+import edu.stanford.protege.webprotege.authorization.ProjectResource;
+import edu.stanford.protege.webprotege.authorization.RoleId;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import edu.stanford.protege.webprotege.user.UserDetailsManager;
+import edu.stanford.protege.webprotege.user.UserLookupException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static edu.stanford.protege.webprotege.authorization.Subject.forUser;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link ProjectSharingSettingsManagerImpl#setProjectSharingSettings(UserId, ProjectSharingSettings)}.
+ * Locks in both the acting-user safety net (GH #176) and the per-entry lookup-failure handling
+ * (GH #179) together, since the two behaviours interact.
+ * <p>
+ * The sharing settings map is built from a plain {@link java.util.HashMap} internally, so iteration
+ * order is not deterministic - assertions below only check order-independent invariants (which
+ * entries got roles, whether the safety net ran, whether the call threw).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ProjectSharingSettingsManagerImpl_TestCase {
+
+    @Mock
+    private AccessManager accessManager;
+
+    @Mock
+    private UserDetailsManager userLookup;
+
+    private ProjectSharingSettingsManagerImpl manager;
+
+    private final ProjectId projectId = MockingUtils.mockProjectId();
+
+    private final ProjectResource projectResource = new ProjectResource(projectId);
+
+    private final UserId actingUserId = MockingUtils.mockUserId();
+
+    @BeforeEach
+    public void setUp() {
+        manager = new ProjectSharingSettingsManagerImpl(accessManager, userLookup);
+    }
+
+    @Test
+    public void shouldSkipConfirmedNotFoundEntryWithoutThrowing() {
+        PersonId unresolvedPersonId = PersonId.get("unresolved-person");
+        when(userLookup.getUserByUserIdOrEmail(unresolvedPersonId.getId())).thenReturn(Optional.empty());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(unresolvedPersonId, SharingPermission.EDIT)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        verify(userLookup).getUserByUserIdOrEmail(unresolvedPersonId.getId());
+        // No lookup resolved to a specific user, and the acting user had no prior access
+        // (unstubbed getAssignedRoles returns empty), so the safety net must not have fired either.
+        verify(accessManager, never()).setAssignedRoles(argThat(subject -> subject.getUserId().isPresent()),
+                                                          eq(projectResource),
+                                                          any());
+    }
+
+    @Test
+    public void shouldContinueProcessingRemainingEntriesAndThrowWhenOneEntryLookupFails() {
+        UserId resolvedUserId = MockingUtils.mockUserId();
+        PersonId failingPersonId = PersonId.get("failing-person");
+        PersonId resolvedPersonId = PersonId.of(resolvedUserId);
+        UserLookupException lookupException = new UserLookupException("boom", new RuntimeException("cause"));
+
+        when(userLookup.getUserByUserIdOrEmail(failingPersonId.getId())).thenThrow(lookupException);
+        when(userLookup.getUserByUserIdOrEmail(resolvedPersonId.getId())).thenReturn(Optional.of(resolvedUserId));
+
+        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
+        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
+                .thenReturn(actingUserRolesBeforeChange);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(failingPersonId, SharingPermission.EDIT),
+                        new SharingSetting(resolvedPersonId, SharingPermission.VIEW)));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(lookupException));
+
+        // The other entry was still processed even though the first one's lookup failed.
+        verify(accessManager).setAssignedRoles(eq(forUser(resolvedUserId)),
+                                                eq(projectResource),
+                                                eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
+        // The acting-user safety net still ran unconditionally (they were not part of the settings).
+        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
+                                                eq(projectResource),
+                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+    }
+
+    @Test
+    public void shouldRestoreActingUsersAccessAndThrowWhenActingUsersOwnLookupFails() {
+        PersonId actingUserPersonId = PersonId.of(actingUserId);
+        UserLookupException lookupException = new UserLookupException("boom", new RuntimeException("cause"));
+        when(userLookup.getUserByUserIdOrEmail(actingUserPersonId.getId())).thenThrow(lookupException);
+
+        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
+        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
+                .thenReturn(actingUserRolesBeforeChange);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(actingUserPersonId, SharingPermission.EDIT)));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(lookupException));
+
+        // Safety net restored the acting user's pre-existing access even though their own entry
+        // failed to resolve.
+        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
+                                                eq(projectResource),
+                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+    }
+
+    @Test
+    public void shouldNotOverwriteActingUsersOwnRolesWhenTheirOwnEntryResolvesSuccessfully() {
+        PersonId actingUserPersonId = PersonId.of(actingUserId);
+        when(userLookup.getUserByUserIdOrEmail(actingUserPersonId.getId())).thenReturn(Optional.of(actingUserId));
+
+        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
+        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
+                .thenReturn(actingUserRolesBeforeChange);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(actingUserPersonId, SharingPermission.VIEW)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        // The acting user's entry resolved and their submitted role was applied - the safety net
+        // must not have separately restored their pre-existing role on top of / instead of it.
+        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
+                                                eq(projectResource),
+                                                eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(actingUserId)),
+                                                          eq(projectResource),
+                                                          eq(new HashSet<>(actingUserRolesBeforeChange)));
+    }
+
+    @Test
+    public void shouldContinueProcessingRemainingEntriesAndThrowWhenOneEntryIsADuplicateMatch() {
+        UserId resolvedUserId = MockingUtils.mockUserId();
+        PersonId duplicatePersonId = PersonId.get("duplicate-person");
+        PersonId resolvedPersonId = PersonId.of(resolvedUserId);
+        RuntimeException duplicateUserException = new RuntimeException("Duplicated user with username duplicate-person");
+
+        when(userLookup.getUserByUserIdOrEmail(duplicatePersonId.getId())).thenThrow(duplicateUserException);
+        when(userLookup.getUserByUserIdOrEmail(resolvedPersonId.getId())).thenReturn(Optional.of(resolvedUserId));
+
+        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
+        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
+                .thenReturn(actingUserRolesBeforeChange);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(duplicatePersonId, SharingPermission.EDIT),
+                        new SharingSetting(resolvedPersonId, SharingPermission.VIEW)));
+
+        // A duplicate-match RuntimeException (a data-integrity problem, not a UserLookupException)
+        // is deliberately given the same treatment as an infra failure at this call site: the entry
+        // is skipped, remaining entries are still processed, the safety net still runs, and the
+        // failure still surfaces at the end - see GH #179 spec Design Notes.
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(duplicateUserException));
+
+        verify(accessManager).setAssignedRoles(eq(forUser(resolvedUserId)),
+                                                eq(projectResource),
+                                                eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
+        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
+                                                eq(projectResource),
+                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+    }
+
+    @Test
+    public void shouldRestoreActingUsersAccessWithoutThrowingWhenActingUserNotInSettingsAndNoLookupFailures() {
+        UserId otherUserId = MockingUtils.mockUserId();
+        PersonId otherPersonId = PersonId.of(otherUserId);
+        when(userLookup.getUserByUserIdOrEmail(otherPersonId.getId())).thenReturn(Optional.of(otherUserId));
+
+        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
+        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
+                .thenReturn(actingUserRolesBeforeChange);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(otherPersonId, SharingPermission.VIEW)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        verify(accessManager).setAssignedRoles(eq(forUser(otherUserId)),
+                                                eq(projectResource),
+                                                eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
+        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
+                                                eq(projectResource),
+                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+    }
+}


### PR DESCRIPTION
## Summary

- `UserDetailsManagerImpl.getUserByUserIdOrEmail()` caught every failure (timeout, RPC exception, even a duplicate-match) into the same `Optional.empty()` used for "this person genuinely doesn't exist" - callers couldn't tell a transient infra hiccup apart from a confirmed non-user.
- Introduces `UserLookupException`, thrown on infra failure (timeout, RPC/messaging exception); `Optional.empty()` now means only "confirmed no such user." The duplicate-match case, previously swallowed by the same catch-all, now propagates too.
- `ProjectSharingSettingsManagerImpl.setProjectSharingSettings` keeps processing every remaining entry after one lookup fails (unchanged from today's continue-on-failure behavior), still runs the acting-user safety net from #176 unconditionally, then rethrows at the end - so the caller sees a real error instead of a false success.
- Restores the interrupt flag on `InterruptedException`, and preserves an earlier recorded lookup failure via `addSuppressed` if the safety net's own write later fails.

## Known, deliberately out-of-scope limitations

- `setProjectSharingSettings` is non-atomic (wipes all role assignments, then re-applies one entry at a time), so a failure partway through can leave a half-applied set of changes. Pre-existing, not worsened by this fix - same data outcome as before, just now visibly signaled instead of silently swallowed.
- Non-acting collaborators still have no safety net if their own lookup fails - only the acting user is protected, per #176's deliberate scope.
- Both are properly addressed by the diff-based rewrite already tracked as #178, which would mean only entries whose sharing setting actually changed are ever looked up or touched.

## Test plan

- [x] `mvn test -Dtest=UserDetailsManagerImpl_TestCase,ProjectSharingSettingsManagerImpl_TestCase` - 8 + 6 tests, all green (first-ever coverage added for `ProjectSharingSettingsManagerImpl`)
- [x] Full `mvn test` - 1818 tests, 0 failures
