### PR TITLE
Only update sharing roles that actually changed

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManager.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManager.java
@@ -13,12 +13,35 @@ import javax.annotation.Nonnull;
 public interface ProjectSharingSettingsManager {
 
     /**
-     * @param actingUserId The user making this change. Implementations must
-     *                     not leave this user without the access they had
-     *                     before the call, even if their entry in
-     *                     {@code projectSharingSettings} (if present) fails
-     *                     to resolve - otherwise a user can lock themselves
-     *                     out of a project they were just editing.
+     * Applies the submitted sharing settings as a diff against the project's current sharing state,
+     * rather than wiping and re-granting every subject's access. Each submitted person-level entry
+     * is first resolved to a {@link edu.stanford.protege.webprotege.common.UserId}; only entries
+     * that resolve and would actually change a subject's sharing role result in a call to update
+     * that subject's roles, and each such call - including for link sharing, which has no lookup of
+     * its own to resolve - preserves any non-sharing roles the subject already holds (e.g.
+     * {@code PROJECT_DOWNLOADER}, {@code LAYOUT_EDITOR}). A resolved entry that turns out to be the
+     * guest user is ignored - the guest user is never treated as an individual collaborator.
+     * <p>
+     * A current collaborator who is absent from {@code projectSharingSettings} has their sharing
+     * role removed (again preserving non-sharing roles) <strong>unless</strong> any entry in this
+     * call failed to resolve (threw {@link edu.stanford.protege.webprotege.user.UserLookupException}
+     * or the duplicate-match {@link RuntimeException}) - a lookup failure anywhere in the batch
+     * structurally cannot be mapped to a specific person, so it must never be allowed to imply
+     * anyone's removal. A confirmed-absent lookup result (i.e. no such user exists) is not a failure
+     * and does not block removals elsewhere in the same call.
+     *
+     * @param actingUserId The user making this change. This user is never a removal candidate -
+     *                     their access is left completely untouched unless their own entry is
+     *                     present in {@code projectSharingSettings} and resolves, in which case it
+     *                     is applied like any other entry. This guarantees a user can never lock
+     *                     themselves out of a project they are actively editing sharing settings
+     *                     for, even if their own lookup fails or they are simply omitted.
+     * @throws RuntimeException the recorded lookup failure (if any occurred while resolving
+     *                     submitted entries), rethrown after all other entries and removals have
+     *                     been processed. If applying a change afterwards itself fails (e.g. an
+     *                     unrelated {@code AccessManager} failure), that failure is thrown instead,
+     *                     with any already-recorded lookup failure attached to it as a suppressed
+     *                     exception rather than lost.
      */
     void setProjectSharingSettings(@Nonnull UserId actingUserId, @Nonnull ProjectSharingSettings projectSharingSettings);
 

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
@@ -1,6 +1,5 @@
 package edu.stanford.protege.webprotege.sharing;
 
-import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.access.AccessManager;
 import edu.stanford.protege.webprotege.authorization.ProjectResource;
 import edu.stanford.protege.webprotege.authorization.RoleId;
@@ -66,33 +65,16 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
         ProjectId projectId = settings.getProjectId();
         ProjectResource projectResource = new ProjectResource(projectId);
 
-        // Capture the acting user's roles before making any changes. The
-        // person-lookup below is a best-effort, search-based existence
-        // check that can fail even for a real, currently signed-in user
-        // (transient RPC failure, timeout, indexing gaps) - if that
-        // happens for the acting user's own entry, or they are simply not
-        // included in the submitted settings, we still must not leave them
-        // without the access they had a moment ago. Losing your own access
-        // to a project you are actively editing sharing settings for is a
-        // lockout with no way back in short of direct DB intervention.
-        Collection<RoleId> actingUserRolesBeforeChange =
-                accessManager.getAssignedRoles(forUser(actingUserId), projectResource);
-
-        // Remove existing assignments
-        accessManager.getSubjectsWithAccessToResource(projectResource)
-                .forEach(subject -> accessManager.setAssignedRoles(subject, projectResource, Collections.emptySet()));
-
         Map<PersonId, SharingSetting> map = settings.getSharingSettings().stream()
                                                     .collect(toMap(SharingSetting::getPersonId, s -> s, (s1, s2) -> s1));
-        Optional<SharingPermission> linkSharingPermission = settings.getLinkSharingPermission();
-        linkSharingPermission.ifPresent(permission -> {
-            Collection<RoleId> roleId = Roles.fromSharingPermission(permission);
-            accessManager.setAssignedRoles(forAnySignedInUser(), projectResource, roleId);
-        });
-        if(!linkSharingPermission.isPresent()) {
-            accessManager.setAssignedRoles(forAnySignedInUser(), projectResource, emptySet());
-        }
-        boolean actingUserRoleWasSet = false;
+
+        // Phase 1: resolve every submitted entry to a UserId first. A lookup failure (an infra
+        // error, or the duplicate-match RuntimeException) for one entry must never affect any
+        // other person's access - keep processing the rest, remember the first failure (with
+        // later ones suppressed onto it), and rethrow it at the end. A confirmed-absent
+        // (Optional.empty()) result is not a failure: it carries no identity ambiguity, so it must
+        // not gate the removal step below.
+        Map<UserId, SharingPermission> desiredByUser = new HashMap<>();
         RuntimeException lookupFailure = null;
         for (SharingSetting setting : map.values()) {
             PersonId personId = setting.getPersonId();
@@ -113,12 +95,14 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
                 continue;
             }
             if (userId.isPresent()) {
-                ImmutableSet<RoleId> roles = Roles.fromSharingPermission(setting.getSharingPermission());
-                accessManager.setAssignedRoles(forUser(userId.get()),
-                                               projectResource,
-                                               roles);
-                if (userId.get().equals(actingUserId)) {
-                    actingUserRoleWasSet = true;
+                if (userId.get().isGuest()) {
+                    logger.warn("Resolved user for a project sharing setting (person id '{}', project {}) is " +
+                                "the guest user - ignoring, the guest user is never an individual collaborator.",
+                                personId.getId(), projectId);
+                }
+                else if (desiredByUser.put(userId.get(), setting.getSharingPermission()) != null) {
+                    logger.warn("More than one submitted sharing setting resolved to the same user ({}) for " +
+                                "project {} - only the last one processed will be applied.", userId.get(), projectId);
                 }
             }
             else {
@@ -130,25 +114,85 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
             }
         }
 
-        // Safety net: never let this call remove the acting user's own
-        // access. If their entry did not resolve above, or they were not
-        // part of the submitted settings at all, restore whatever access
-        // they had immediately before this call.
-        if (!actingUserRoleWasSet && !actingUserRolesBeforeChange.isEmpty()) {
-            logger.warn("Restoring user {}'s pre-existing access to project {} because the submitted " +
-                        "sharing settings would otherwise have removed it.", actingUserId, projectId);
-            try {
-                accessManager.setAssignedRoles(forUser(actingUserId), projectResource, new HashSet<>(actingUserRolesBeforeChange));
-            } catch (RuntimeException e) {
-                if (lookupFailure != null) {
-                    e.addSuppressed(lookupFailure);
-                }
-                throw e;
+        // Phases 2-5 are wrapped so that if any of them throws (e.g. an AccessManager RPC failure
+        // unrelated to a lookup), an already-recorded lookupFailure is not silently lost - it is
+        // attached to the new exception as a suppressed cause, matching how the old #176 safety net
+        // protected its own write in the same way.
+        try {
+            // Phase 2: load each current collaborator's raw role set (never on raw PersonId - the
+            // same person can appear as textually different PersonId values across current vs.
+            // submitted state). This both drives the diff below and lets us preserve each subject's
+            // non-sharing roles across updates and removals.
+            Map<UserId, Collection<RoleId>> currentByUser = new HashMap<>();
+            accessManager.getSubjectsWithAccessToResource(projectResource).stream()
+                         .filter(subject -> !subject.isGuest())
+                         .filter(subject -> subject.getUserId().isPresent())
+                         .forEach(subject -> currentByUser.put(subject.getUserId().get(),
+                                                                accessManager.getAssignedRoles(subject, projectResource)));
+
+            // Phase 3: link sharing - only touch it if the submitted permission actually differs
+            // from the current one, preserving any non-sharing roles forAnySignedInUser() holds
+            // (e.g. the default LAYOUT_EDITOR grant), exactly like every other subject below.
+            Collection<RoleId> currentLinkSharingRoles = accessManager.getAssignedRoles(forAnySignedInUser(), projectResource);
+            Optional<SharingPermission> currentLinkSharingPermission = Roles.toSharingPermission(currentLinkSharingRoles);
+            Optional<SharingPermission> desiredLinkSharingPermission = settings.getLinkSharingPermission();
+            if (!currentLinkSharingPermission.equals(desiredLinkSharingPermission)) {
+                Set<RoleId> newLinkSharingRoles = nonSharingSubset(currentLinkSharingRoles);
+                desiredLinkSharingPermission.ifPresent(
+                        permission -> newLinkSharingRoles.addAll(Roles.fromSharingPermission(permission)));
+                accessManager.setAssignedRoles(forAnySignedInUser(), projectResource, newLinkSharingRoles);
             }
+
+            // Phase 4: additions/updates. Skip the call entirely for anything that would not
+            // actually change; otherwise preserve the subject's non-sharing roles alongside the new
+            // sharing role.
+            desiredByUser.forEach((userId, desiredPermission) -> {
+                Collection<RoleId> currentRoles = currentByUser.getOrDefault(userId, emptySet());
+                if (Roles.toSharingPermission(currentRoles).equals(Optional.of(desiredPermission))) {
+                    return;
+                }
+                Set<RoleId> newRoles = nonSharingSubset(currentRoles);
+                newRoles.addAll(Roles.fromSharingPermission(desiredPermission));
+                accessManager.setAssignedRoles(forUser(userId), projectResource, newRoles);
+            });
+
+            // Phase 5: removals - only when every entry resolved without a lookup failure this
+            // call. A failure anywhere in the batch structurally cannot be mapped to a specific
+            // person, so it must not be allowed to imply anyone's removal. The acting user is never
+            // a removal candidate, unconditionally - this is what makes the old #176 restore-net
+            // unnecessary: the acting user can now only ever be updated (their own entry resolving)
+            // or left completely untouched (never a removal candidate).
+            if (lookupFailure == null) {
+                currentByUser.forEach((userId, currentRoles) -> {
+                    if (userId.equals(actingUserId) || desiredByUser.containsKey(userId)) {
+                        return;
+                    }
+                    if (Roles.toSharingPermission(currentRoles).isPresent()) {
+                        accessManager.setAssignedRoles(forUser(userId), projectResource, nonSharingSubset(currentRoles));
+                    }
+                });
+            }
+        }
+        catch (RuntimeException e) {
+            if (lookupFailure != null) {
+                e.addSuppressed(lookupFailure);
+            }
+            throw e;
         }
 
         if (lookupFailure != null) {
             throw lookupFailure;
         }
+    }
+
+    /**
+     * @return a mutable copy of {@code roles} with the sharing-related roles
+     * ({@link Roles#SHARING_ROLE_IDS}) removed, i.e. the roles that should be preserved when a
+     * subject's sharing permission is updated or removed.
+     */
+    private static Set<RoleId> nonSharingSubset(Collection<RoleId> roles) {
+        Set<RoleId> subset = new HashSet<>(roles);
+        subset.removeAll(Roles.SHARING_ROLE_IDS);
+        return subset;
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/Roles.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/Roles.java
@@ -15,6 +15,15 @@ import static edu.stanford.protege.webprotege.access.BuiltInRole.*;
  */
 public class Roles {
 
+    /**
+     * The four {@link RoleId}s that represent a sharing permission (i.e. the ones that
+     * {@link #toSharingPermission(Collection)} and {@link #fromSharingPermission(SharingPermission)}
+     * translate to and from a {@link SharingPermission}). Used to compute the subset of a subject's
+     * roles that should be preserved (as opposed to replaced) when their sharing permission changes.
+     */
+    public static final ImmutableSet<RoleId> SHARING_ROLE_IDS = ImmutableSet.of(
+            CAN_VIEW.getRoleId(), CAN_COMMENT.getRoleId(), CAN_EDIT.getRoleId(), CAN_MANAGE.getRoleId());
+
     public  static Optional<SharingPermission> toSharingPermission(Collection<RoleId> roles) {
         if(roles.contains(CAN_MANAGE.getRoleId())) {
             return Optional.of(SharingPermission.MANAGE);

--- a/src/test/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl_TestCase.java
@@ -4,6 +4,7 @@ import edu.stanford.protege.webprotege.MockingUtils;
 import edu.stanford.protege.webprotege.access.AccessManager;
 import edu.stanford.protege.webprotege.authorization.ProjectResource;
 import edu.stanford.protege.webprotege.authorization.RoleId;
+import edu.stanford.protege.webprotege.authorization.Subject;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.common.UserId;
 import edu.stanford.protege.webprotege.user.UserDetailsManager;
@@ -16,30 +17,40 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static edu.stanford.protege.webprotege.access.BuiltInRole.CAN_EDIT;
+import static edu.stanford.protege.webprotege.access.BuiltInRole.CAN_VIEW;
+import static edu.stanford.protege.webprotege.authorization.Subject.forAnySignedInUser;
 import static edu.stanford.protege.webprotege.authorization.Subject.forUser;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Covers {@link ProjectSharingSettingsManagerImpl#setProjectSharingSettings(UserId, ProjectSharingSettings)}.
- * Locks in both the acting-user safety net (GH #176) and the per-entry lookup-failure handling
- * (GH #179) together, since the two behaviours interact.
+ * <p>
+ * The implementation diffs the submitted settings against the project's current sharing state
+ * (keyed on resolved {@link UserId}, never on raw {@link PersonId}) rather than wiping and
+ * re-granting every subject's access. These tests lock in that diff behaviour together with the
+ * per-entry lookup-failure handling from GH #179 and the removal-gating / acting-user-exclusion /
+ * non-sharing-role-preservation rules from GH #178, since they all interact.
  * <p>
  * The sharing settings map is built from a plain {@link java.util.HashMap} internally, so iteration
  * order is not deterministic - assertions below only check order-independent invariants (which
- * entries got roles, whether the safety net ran, whether the call threw).
+ * entries got roles, which did not, whether the call threw).
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -59,10 +70,37 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
 
     private final UserId actingUserId = MockingUtils.mockUserId();
 
+    /**
+     * Subjects accumulated so far by {@link #givenCurrentAccess(UserId, RoleId...)}, backing the
+     * stub for {@link AccessManager#getSubjectsWithAccessToResource(edu.stanford.protege.webprotege.authorization.Resource)}.
+     */
+    private final List<Subject> currentSubjects = new ArrayList<>();
+
     @BeforeEach
     public void setUp() {
         manager = new ProjectSharingSettingsManagerImpl(accessManager, userLookup);
     }
+
+    /**
+     * Registers {@code userId} as currently holding {@code roleIds} on {@link #projectResource}.
+     * <p>
+     * The implementation under test populates its notion of "current access" purely by iterating
+     * whatever {@link AccessManager#getSubjectsWithAccessToResource} returns and then calling
+     * {@link AccessManager#getAssignedRoles} for each such subject - stubbing only
+     * {@code getAssignedRoles} for a user is not enough, since that user would never be discovered
+     * in the first place. This helper stubs both consistently, accumulating subjects across calls
+     * so a test can build up current state incrementally.
+     */
+    private void givenCurrentAccess(UserId userId, RoleId... roleIds) {
+        Subject subject = forUser(userId);
+        currentSubjects.add(subject);
+        when(accessManager.getSubjectsWithAccessToResource(projectResource)).thenReturn(currentSubjects);
+        when(accessManager.getAssignedRoles(subject, projectResource)).thenReturn(Set.of(roleIds));
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Lookup resolution (GH #179) - rewritten to assert against the new diff-based behaviour.
+    // ----------------------------------------------------------------------------------------
 
     @Test
     public void shouldSkipConfirmedNotFoundEntryWithoutThrowing() {
@@ -74,14 +112,12 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
                 Optional.empty(),
                 List.of(new SharingSetting(unresolvedPersonId, SharingPermission.EDIT)));
 
-        manager.setProjectSharingSettings(actingUserId, settings);
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
 
         verify(userLookup).getUserByUserIdOrEmail(unresolvedPersonId.getId());
-        // No lookup resolved to a specific user, and the acting user had no prior access
-        // (unstubbed getAssignedRoles returns empty), so the safety net must not have fired either.
-        verify(accessManager, never()).setAssignedRoles(argThat(subject -> subject.getUserId().isPresent()),
-                                                          eq(projectResource),
-                                                          any());
+        // Nothing resolved to a specific user, there is no current access to diff against, and
+        // link sharing was not submitted and was not previously set - nothing to do at all.
+        verify(accessManager, never()).setAssignedRoles(any(), eq(projectResource), any());
     }
 
     @Test
@@ -94,9 +130,7 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
         when(userLookup.getUserByUserIdOrEmail(failingPersonId.getId())).thenThrow(lookupException);
         when(userLookup.getUserByUserIdOrEmail(resolvedPersonId.getId())).thenReturn(Optional.of(resolvedUserId));
 
-        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
-        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
-                .thenReturn(actingUserRolesBeforeChange);
+        givenCurrentAccess(actingUserId, new RoleId("PreExistingRole"));
 
         ProjectSharingSettings settings = new ProjectSharingSettings(
                 projectId,
@@ -112,21 +146,18 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
         verify(accessManager).setAssignedRoles(eq(forUser(resolvedUserId)),
                                                 eq(projectResource),
                                                 eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
-        // The acting-user safety net still ran unconditionally (they were not part of the settings).
-        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
-                                                eq(projectResource),
-                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+        // The acting user is never a removal candidate, and a lookup failure occurred, so removals
+        // were not even computed - either way, the acting user must not have been touched at all.
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(actingUserId)), eq(projectResource), any());
     }
 
     @Test
-    public void shouldRestoreActingUsersAccessAndThrowWhenActingUsersOwnLookupFails() {
+    public void shouldLeaveActingUsersAccessUntouchedWhenActingUsersOwnLookupFails() {
         PersonId actingUserPersonId = PersonId.of(actingUserId);
         UserLookupException lookupException = new UserLookupException("boom", new RuntimeException("cause"));
         when(userLookup.getUserByUserIdOrEmail(actingUserPersonId.getId())).thenThrow(lookupException);
 
-        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
-        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
-                .thenReturn(actingUserRolesBeforeChange);
+        givenCurrentAccess(actingUserId, new RoleId("PreExistingRole"));
 
         ProjectSharingSettings settings = new ProjectSharingSettings(
                 projectId,
@@ -137,11 +168,9 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
                                                 () -> manager.setProjectSharingSettings(actingUserId, settings));
         assertThat(thrown, is(lookupException));
 
-        // Safety net restored the acting user's pre-existing access even though their own entry
-        // failed to resolve.
-        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
-                                                eq(projectResource),
-                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+        // The acting user is never a removal candidate - since their own entry failed to resolve,
+        // it is as if they were not submitted at all, and their access is left completely alone.
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(actingUserId)), eq(projectResource), any());
     }
 
     @Test
@@ -149,9 +178,7 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
         PersonId actingUserPersonId = PersonId.of(actingUserId);
         when(userLookup.getUserByUserIdOrEmail(actingUserPersonId.getId())).thenReturn(Optional.of(actingUserId));
 
-        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
-        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
-                .thenReturn(actingUserRolesBeforeChange);
+        givenCurrentAccess(actingUserId, new RoleId("PreExistingRole"));
 
         ProjectSharingSettings settings = new ProjectSharingSettings(
                 projectId,
@@ -160,14 +187,15 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
 
         manager.setProjectSharingSettings(actingUserId, settings);
 
-        // The acting user's entry resolved and their submitted role was applied - the safety net
-        // must not have separately restored their pre-existing role on top of / instead of it.
-        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
-                                                eq(projectResource),
-                                                eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
-        verify(accessManager, never()).setAssignedRoles(eq(forUser(actingUserId)),
-                                                          eq(projectResource),
-                                                          eq(new HashSet<>(actingUserRolesBeforeChange)));
+        // The acting user's own entry resolved with a new permission - it is applied like any other
+        // update, preserving their pre-existing non-sharing role alongside the new sharing role.
+        Set<RoleId> expectedRoles = new HashSet<>(Set.of(new RoleId("PreExistingRole")));
+        expectedRoles.addAll(Roles.fromSharingPermission(SharingPermission.VIEW));
+        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)), eq(projectResource), eq(expectedRoles));
+        // ... and that was the only call made for the acting user - no separate restore of their
+        // old role set on top of / instead of it.
+        verify(accessManager, times(1))
+                .setAssignedRoles(eq(forUser(actingUserId)), eq(projectResource), any());
     }
 
     @Test
@@ -180,9 +208,7 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
         when(userLookup.getUserByUserIdOrEmail(duplicatePersonId.getId())).thenThrow(duplicateUserException);
         when(userLookup.getUserByUserIdOrEmail(resolvedPersonId.getId())).thenReturn(Optional.of(resolvedUserId));
 
-        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
-        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
-                .thenReturn(actingUserRolesBeforeChange);
+        givenCurrentAccess(actingUserId, new RoleId("PreExistingRole"));
 
         ProjectSharingSettings settings = new ProjectSharingSettings(
                 projectId,
@@ -192,8 +218,8 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
 
         // A duplicate-match RuntimeException (a data-integrity problem, not a UserLookupException)
         // is deliberately given the same treatment as an infra failure at this call site: the entry
-        // is skipped, remaining entries are still processed, the safety net still runs, and the
-        // failure still surfaces at the end - see GH #179 spec Design Notes.
+        // is skipped, remaining entries are still processed, and the failure still surfaces at the
+        // end - see GH #179 spec Design Notes.
         RuntimeException thrown = assertThrows(RuntimeException.class,
                                                 () -> manager.setProjectSharingSettings(actingUserId, settings));
         assertThat(thrown, is(duplicateUserException));
@@ -201,33 +227,316 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
         verify(accessManager).setAssignedRoles(eq(forUser(resolvedUserId)),
                                                 eq(projectResource),
                                                 eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
-        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
-                                                eq(projectResource),
-                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(actingUserId)), eq(projectResource), any());
     }
 
     @Test
-    public void shouldRestoreActingUsersAccessWithoutThrowingWhenActingUserNotInSettingsAndNoLookupFailures() {
+    public void shouldLeaveActingUsersAccessUntouchedWithoutThrowingWhenActingUserNotInSettingsAndNoLookupFailures() {
         UserId otherUserId = MockingUtils.mockUserId();
         PersonId otherPersonId = PersonId.of(otherUserId);
         when(userLookup.getUserByUserIdOrEmail(otherPersonId.getId())).thenReturn(Optional.of(otherUserId));
 
-        Set<RoleId> actingUserRolesBeforeChange = Set.of(new RoleId("PreExistingRole"));
-        when(accessManager.getAssignedRoles(forUser(actingUserId), projectResource))
-                .thenReturn(actingUserRolesBeforeChange);
+        // The acting user currently holds an actual sharing role (not just some unrelated role) -
+        // if the acting user were not unconditionally excluded from removal candidates, this would
+        // otherwise look exactly like a legitimate removal.
+        givenCurrentAccess(actingUserId, CAN_VIEW.getRoleId());
 
         ProjectSharingSettings settings = new ProjectSharingSettings(
                 projectId,
                 Optional.empty(),
                 List.of(new SharingSetting(otherPersonId, SharingPermission.VIEW)));
 
-        manager.setProjectSharingSettings(actingUserId, settings);
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
 
         verify(accessManager).setAssignedRoles(eq(forUser(otherUserId)),
                                                 eq(projectResource),
                                                 eq(Roles.fromSharingPermission(SharingPermission.VIEW)));
-        verify(accessManager).setAssignedRoles(eq(forUser(actingUserId)),
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(actingUserId)), eq(projectResource), any());
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Diff / removal-gating / role-preservation scenarios (GH #178).
+    // ----------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldSkipSetAssignedRolesForNoOpEntry() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        PersonId collaboratorPersonId = PersonId.of(collaboratorId);
+        when(userLookup.getUserByUserIdOrEmail(collaboratorPersonId.getId())).thenReturn(Optional.of(collaboratorId));
+
+        givenCurrentAccess(collaboratorId, CAN_VIEW.getRoleId());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(collaboratorPersonId, SharingPermission.VIEW)));
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldClearCollaboratorsSharingRoleWhenAbsentFromSubmittedSettingsAndNoLookupFailures() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        givenCurrentAccess(collaboratorId, CAN_VIEW.getRoleId());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of());
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        verify(accessManager).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), eq(Set.of()));
+    }
+
+    @Test
+    public void shouldNotRemoveCollaboratorWhenAnotherEntryLookupFailsThisCall() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        givenCurrentAccess(collaboratorId, CAN_VIEW.getRoleId());
+
+        PersonId failingPersonId = PersonId.get("failing-person");
+        UserLookupException lookupException = new UserLookupException("boom", new RuntimeException("cause"));
+        when(userLookup.getUserByUserIdOrEmail(failingPersonId.getId())).thenThrow(lookupException);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(failingPersonId, SharingPermission.EDIT)));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(lookupException));
+
+        // The collaborator would otherwise have been dropped (absent from the submitted list), but
+        // a failure elsewhere in the same call must block that removal entirely.
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldRemoveCollaboratorWhenAnotherEntryIsOnlyConfirmedAbsentNotAFailure() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        givenCurrentAccess(collaboratorId, CAN_VIEW.getRoleId());
+
+        PersonId unresolvedPersonId = PersonId.get("unresolved-person");
+        when(userLookup.getUserByUserIdOrEmail(unresolvedPersonId.getId())).thenReturn(Optional.empty());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(unresolvedPersonId, SharingPermission.EDIT)));
+
+        // A confirmed-absent result carries no identity ambiguity, so it must not gate the removal
+        // of an unrelated, legitimately-dropped collaborator - the call must not throw either.
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        verify(accessManager).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), eq(Set.of()));
+    }
+
+    @Test
+    public void shouldNotTouchUnrelatedNoOpCollaboratorWhenAnotherEntryFails() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        PersonId collaboratorPersonId = PersonId.of(collaboratorId);
+        when(userLookup.getUserByUserIdOrEmail(collaboratorPersonId.getId())).thenReturn(Optional.of(collaboratorId));
+        givenCurrentAccess(collaboratorId, CAN_VIEW.getRoleId());
+
+        PersonId failingPersonId = PersonId.get("failing-person");
+        UserLookupException lookupException = new UserLookupException("boom", new RuntimeException("cause"));
+        when(userLookup.getUserByUserIdOrEmail(failingPersonId.getId())).thenThrow(lookupException);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(collaboratorPersonId, SharingPermission.VIEW),
+                        new SharingSetting(failingPersonId, SharingPermission.EDIT)));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(lookupException));
+
+        // The collaborator's submitted permission matches their current one (a no-op) and a wholly
+        // unrelated entry failed - neither reason permits touching their access.
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldSkipSetAssignedRolesForLinkSharingWhenSubmittedPermissionMatchesCurrent() {
+        when(accessManager.getAssignedRoles(forAnySignedInUser(), projectResource))
+                .thenReturn(Set.of(CAN_EDIT.getRoleId()));
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.of(SharingPermission.EDIT),
+                List.of());
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        verify(accessManager, never()).setAssignedRoles(eq(forAnySignedInUser()), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldPreserveNonSharingRoleWhenCollaboratorsSharingRoleIsUpdated() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        PersonId collaboratorPersonId = PersonId.of(collaboratorId);
+        when(userLookup.getUserByUserIdOrEmail(collaboratorPersonId.getId())).thenReturn(Optional.of(collaboratorId));
+
+        givenCurrentAccess(collaboratorId, new RoleId("PreExistingRole"), CAN_VIEW.getRoleId());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(collaboratorPersonId, SharingPermission.EDIT)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        Set<RoleId> expectedRoles = new HashSet<>(Set.of(new RoleId("PreExistingRole")));
+        expectedRoles.addAll(Roles.fromSharingPermission(SharingPermission.EDIT));
+        verify(accessManager).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), eq(expectedRoles));
+    }
+
+    @Test
+    public void shouldPreserveNonSharingRoleWhenCollaboratorsSharingRoleIsRemoved() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        givenCurrentAccess(collaboratorId, new RoleId("PreExistingRole"), CAN_VIEW.getRoleId());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of());
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        verify(accessManager).setAssignedRoles(eq(forUser(collaboratorId)),
                                                 eq(projectResource),
-                                                eq(new HashSet<>(actingUserRolesBeforeChange)));
+                                                eq(Set.of(new RoleId("PreExistingRole"))));
+    }
+
+    @Test
+    public void shouldTreatDuplicateMatchFailureAsBlockingRemovalsJustLikeALookupFailure() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        givenCurrentAccess(collaboratorId, CAN_VIEW.getRoleId());
+
+        PersonId duplicatePersonId = PersonId.get("duplicate-person");
+        RuntimeException duplicateUserException = new RuntimeException("Duplicated user with username duplicate-person");
+        when(userLookup.getUserByUserIdOrEmail(duplicatePersonId.getId())).thenThrow(duplicateUserException);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(duplicatePersonId, SharingPermission.EDIT)));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(duplicateUserException));
+
+        // The duplicate-match RuntimeException is a lookup failure for removal-gating purposes just
+        // as much as a UserLookupException - it must block the otherwise-legitimate removal below.
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldPreserveNonSharingRoleForLinkSharingWhenPermissionChanges() {
+        when(accessManager.getAssignedRoles(forAnySignedInUser(), projectResource))
+                .thenReturn(Set.of(new RoleId("PreExistingLinkRole"), CAN_VIEW.getRoleId()));
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.of(SharingPermission.EDIT),
+                List.of());
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        // Link sharing gets the same non-sharing-role preservation as every other subject.
+        Set<RoleId> expectedRoles = new HashSet<>(Set.of(new RoleId("PreExistingLinkRole")));
+        expectedRoles.addAll(Roles.fromSharingPermission(SharingPermission.EDIT));
+        verify(accessManager).setAssignedRoles(eq(forAnySignedInUser()), eq(projectResource), eq(expectedRoles));
+    }
+
+    @Test
+    public void shouldNotTouchSubjectHoldingOnlyNonSharingRoleWhenAbsentFromSubmittedSettings() {
+        UserId subjectId = MockingUtils.mockUserId();
+        givenCurrentAccess(subjectId, new RoleId("PreExistingRole"));
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of());
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        // This subject never held a sharing role to begin with (only an unrelated one) - they were
+        // never really "in the sharing list", so their absence from the submitted settings must not
+        // trigger any call at all for them.
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(subjectId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldIgnoreEntryThatResolvesToTheGuestUser() {
+        PersonId guestPersonId = PersonId.get("guest-alias");
+        when(userLookup.getUserByUserIdOrEmail(guestPersonId.getId())).thenReturn(Optional.of(UserId.getGuest()));
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(guestPersonId, SharingPermission.EDIT)));
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        // The guest user is never treated as an individual collaborator - resolving to it must not
+        // result in any role-assignment call at all.
+        verify(accessManager, never()).setAssignedRoles(eq(forUser(UserId.getGuest())), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldApplyOnlyOneUpdateWhenTwoSubmittedEntriesResolveToTheSameUser() {
+        UserId collaboratorId = MockingUtils.mockUserId();
+        PersonId emailPersonId = PersonId.get("collaborator@example.com");
+        PersonId usernamePersonId = PersonId.get("collaborator-username");
+        when(userLookup.getUserByUserIdOrEmail(emailPersonId.getId())).thenReturn(Optional.of(collaboratorId));
+        when(userLookup.getUserByUserIdOrEmail(usernamePersonId.getId())).thenReturn(Optional.of(collaboratorId));
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(emailPersonId, SharingPermission.VIEW),
+                        new SharingSetting(usernamePersonId, SharingPermission.EDIT)));
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        // Both submitted entries resolved to the same real person - only one update call is made
+        // for them, not two (whichever permission was processed last wins; iteration order over the
+        // submitted list is not guaranteed, so this only asserts the call count).
+        verify(accessManager, times(1)).setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldAttachLookupFailureAsSuppressedWhenALaterAccessManagerWriteThrows() {
+        PersonId failingPersonId = PersonId.get("failing-person");
+        UserLookupException lookupException = new UserLookupException("boom", new RuntimeException("cause"));
+        when(userLookup.getUserByUserIdOrEmail(failingPersonId.getId())).thenThrow(lookupException);
+
+        UserId collaboratorId = MockingUtils.mockUserId();
+        PersonId collaboratorPersonId = PersonId.of(collaboratorId);
+        when(userLookup.getUserByUserIdOrEmail(collaboratorPersonId.getId())).thenReturn(Optional.of(collaboratorId));
+
+        RuntimeException accessManagerFailure = new RuntimeException("access manager RPC failure");
+        doThrow(accessManagerFailure).when(accessManager)
+                                      .setAssignedRoles(eq(forUser(collaboratorId)), eq(projectResource), any());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(failingPersonId, SharingPermission.EDIT),
+                        new SharingSetting(collaboratorPersonId, SharingPermission.VIEW)));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        // The AccessManager write failure is what's thrown (it happened after the lookup failure
+        // was already recorded), but the earlier lookup failure must not be silently lost.
+        assertThat(thrown, is(accessManagerFailure));
+        assertThat(thrown.getSuppressed().length, is(1));
+        assertThat(thrown.getSuppressed()[0], is(lookupException));
     }
 }


### PR DESCRIPTION
## Summary

- Saving a project's sharing settings used to clear everyone's access first, then hand it back out one person at a time. If looking someone up failed partway through, other people could lose their access with no way to get it back, and unrelated permissions like download access got reset on every single save.
- Now the save only touches the people whose access actually changed. If a lookup fails, nobody's access gets removed on that save, and permissions unrelated to sharing (e.g. download access) are left alone.
- The acting user is still protected from ever losing their own access (this generalizes and replaces the narrower fix from #176).

## Test plan

- [x] `mvn test -Dtest=ProjectSharingSettingsManagerImpl_TestCase` - 20 tests, all green
- [x] Full `mvn test` - 1726 tests, 0 failures