### PR TITLE
Add pending sharing invitations for never-registered users (fixes #177)

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/ApplicationActionHandlerBeansConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ApplicationActionHandlerBeansConfiguration.java
@@ -17,6 +17,7 @@ import edu.stanford.protege.webprotege.permissions.RebuildPermissionsActionHandl
 import edu.stanford.protege.webprotege.perspective.GetPerspectivesActionHandler;
 import edu.stanford.protege.webprotege.perspective.PerspectivesManager;
 import edu.stanford.protege.webprotege.project.*;
+import edu.stanford.protege.webprotege.sharing.PendingSharingInvitationRedeemer;
 import edu.stanford.protege.webprotege.user.UserActivityManager;
 import edu.stanford.protege.webprotege.user.UserDetailsManager;
 import org.springframework.context.annotation.Bean;
@@ -107,7 +108,8 @@ public class ApplicationActionHandlerBeansConfiguration {
 
     @Bean
     GetAuthenticatedUserDetailsActionHandler getAuthenticatedUserDetailsActionHandler(AccessManager p1,
-                                                                                      UserDetailsManager p2) {
-        return new GetAuthenticatedUserDetailsActionHandler(p1, p2);
+                                                                                      UserDetailsManager p2,
+                                                                                      PendingSharingInvitationRedeemer p3) {
+        return new GetAuthenticatedUserDetailsActionHandler(p1, p2, p3);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
@@ -36,6 +36,7 @@ import edu.stanford.protege.webprotege.lang.DefaultDisplayNameSettingsFactory;
 import edu.stanford.protege.webprotege.locking.*;
 import edu.stanford.protege.webprotege.mail.MessageIdGenerator;
 import edu.stanford.protege.webprotege.mail.MessagingExceptionHandlerImpl;
+import edu.stanford.protege.webprotege.mail.SendMail;
 import edu.stanford.protege.webprotege.mail.SendMailImpl;
 import edu.stanford.protege.webprotege.mansyntax.render.DefaultHttpLinkRenderer;
 import edu.stanford.protege.webprotege.mansyntax.render.HttpLinkRenderer;
@@ -52,7 +53,7 @@ import edu.stanford.protege.webprotege.perspective.*;
 import edu.stanford.protege.webprotege.project.*;
 import edu.stanford.protege.webprotege.revision.*;
 import edu.stanford.protege.webprotege.search.EntitySearchFilterRepositoryImpl;
-import edu.stanford.protege.webprotege.sharing.ProjectSharingSettingsManagerImpl;
+import edu.stanford.protege.webprotege.sharing.*;
 import edu.stanford.protege.webprotege.storage.MinioProperties;
 import edu.stanford.protege.webprotege.tag.EntityTagsRepositoryImpl;
 import edu.stanford.protege.webprotege.tag.TagRepositoryImpl;
@@ -545,8 +546,47 @@ public class ApplicationBeansConfiguration {
     }
 
     @Bean
-    ProjectSharingSettingsManagerImpl projectSharingSettingsManager(AccessManager p1, UserDetailsManager p2) {
-        return new ProjectSharingSettingsManagerImpl(p1, p2);
+    ProjectSharingSettingsManagerImpl projectSharingSettingsManager(AccessManager p1,
+                                                                    UserDetailsManager p2,
+                                                                    PendingSharingInvitationRepository p3,
+                                                                    SharingInvitationEmailer p4) {
+        return new ProjectSharingSettingsManagerImpl(p1, p2, p3, p4);
+    }
+
+    @Bean
+    PendingSharingInvitationRepository pendingSharingInvitationRepository(MongoTemplate p1, ObjectMapper p2) {
+        var repository = new PendingSharingInvitationRepositoryImpl(p1, p2);
+        repository.ensureIndexes();
+        return repository;
+    }
+
+    @Bean
+    @SharingInvitationEmailTemplate
+    OverridableFile provideSharingInvitationEmailTemplateFile(OverridableFileFactory factory) {
+        return factory.getOverridableFile("templates/sharing-invitation-email-template.html");
+    }
+
+    @Bean
+    @SharingInvitationEmailTemplate
+    FileContents provideSharingInvitationEmailTemplate(@SharingInvitationEmailTemplate OverridableFile file) {
+        return new FileContents(file);
+    }
+
+    @Bean
+    SharingInvitationEmailer sharingInvitationEmailer(ProjectDetailsRepository p1,
+                                                      UserDetailsManager p2,
+                                                      @SharingInvitationEmailTemplate FileContents p3,
+                                                      TemplateEngine p4,
+                                                      PlaceUrl p5,
+                                                      SendMail p6) {
+        return new SharingInvitationEmailer(p1, p2, p3, p4, p5, p6);
+    }
+
+    @Bean
+    PendingSharingInvitationRedeemer pendingSharingInvitationRedeemer(PendingSharingInvitationRepository p1,
+                                                                      AccessManager p2,
+                                                                      ObjectMapper p3) {
+        return new PendingSharingInvitationRedeemer(p1, p2, p3);
     }
 
 

--- a/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
@@ -351,7 +351,15 @@ public class ApplicationBeansConfiguration {
     @Bean
     @MailProperties
     Properties getMailProperties() {
-        return new Properties();
+        // SendMailImpl reads its JavaMail settings (mail.smtp.host, mail.smtp.port,
+        // mail.smtp.auth, ...) exclusively from this bean, so they must be seeded from
+        // deployment configuration here.  System properties let containers supply them
+        // via -D flags (e.g. JDK_JAVA_OPTIONS) without baking SMTP details into the image.
+        var mailProperties = new Properties();
+        System.getProperties().stringPropertyNames().stream()
+              .filter(name -> name.startsWith("mail."))
+              .forEach(name -> mailProperties.setProperty(name, System.getProperty(name)));
+        return mailProperties;
     }
 
     @Bean

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitation.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitation.java
@@ -1,0 +1,73 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * A sharing invitation for a person who could not be resolved to an existing user when a project
+ * was shared with them.  It records both the id exactly as an owner typed it ({@link #personId})
+ * and a normalized match key ({@link #personKey}) so that the invitation can be matched against a
+ * user's id or verified email claim when they first authenticate.
+ */
+public record PendingSharingInvitation(
+        @JsonProperty(PROJECT_ID) ProjectId projectId,
+        @JsonProperty(PERSON_ID) String personId,
+        @JsonProperty(PERSON_KEY) String personKey,
+        @JsonProperty(SHARING_PERMISSION) SharingPermission sharingPermission,
+        @JsonProperty(INVITED_BY) UserId invitedBy,
+        @JsonProperty(CREATED_AT) Instant createdAt) {
+
+    public static final String PROJECT_ID = "projectId";
+
+    public static final String PERSON_ID = "personId";
+
+    public static final String PERSON_KEY = "personKey";
+
+    public static final String SHARING_PERMISSION = "sharingPermission";
+
+    public static final String INVITED_BY = "invitedBy";
+
+    public static final String CREATED_AT = "createdAt";
+
+    public PendingSharingInvitation {
+        // Reject a null in any component up front so a malformed stored document fails conversion
+        // (which the repository's reads treat as a corrupt-document signal) rather than surfacing as
+        // a later NullPointerException in PersonId.get / sort / fromSharingPermission.
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(personId, "personId must not be null");
+        Objects.requireNonNull(personKey, "personKey must not be null");
+        Objects.requireNonNull(sharingPermission, "sharingPermission must not be null");
+        Objects.requireNonNull(invitedBy, "invitedBy must not be null");
+        Objects.requireNonNull(createdAt, "createdAt must not be null");
+        personId = personId.trim();
+        personKey = normalizeKey(personKey);
+        if (personKey.isEmpty()) {
+            throw new IllegalArgumentException("A pending sharing invitation must have a non-blank person key");
+        }
+    }
+
+    /**
+     * Normalizes a typed person id into a match key by trimming surrounding whitespace and
+     * lower-casing it.  A {@code null} value normalizes to the empty string.  Shared by the code
+     * that writes invitations and the code that matches them on login so both agree on what makes
+     * two ids "the same person".
+     */
+    public static String normalizeKey(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * @return whether {@code key} looks like an email address (i.e. contains an {@code '@'}).
+     * Applied to a normalized key so the manager's "send an email invitation" gate and the
+     * redeemer's "match only via a verified email claim" path can never disagree on what counts as
+     * email-shaped.
+     */
+    public static boolean isEmailShaped(String key) {
+        return key != null && key.contains("@");
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRedeemer.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRedeemer.java
@@ -1,0 +1,201 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.stanford.protege.webprotege.access.AccessManager;
+import edu.stanford.protege.webprotege.authorization.ProjectResource;
+import edu.stanford.protege.webprotege.authorization.RoleId;
+import edu.stanford.protege.webprotege.common.UserId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static edu.stanford.protege.webprotege.authorization.Subject.forUser;
+import static edu.stanford.protege.webprotege.sharing.PendingSharingInvitation.normalizeKey;
+
+/**
+ * Grants and consumes any {@link PendingSharingInvitation}s that match a user the first time they
+ * arrive authenticated.  Because there is no login event anywhere in the service, this runs from
+ * {@link edu.stanford.protege.webprotege.user.GetAuthenticatedUserDetailsActionHandler} at session
+ * bootstrap; idempotency comes from consuming (deleting) each invitation as it is granted.
+ * <p>
+ * The trust model is deliberately narrow: an email-shaped invitation is only ever redeemed against
+ * a matching {@code email} claim whose {@code email_verified} is true - never against the username,
+ * even in deployments where the username equals the email address.
+ */
+public class PendingSharingInvitationRedeemer {
+
+    private static final String EMAIL_CLAIM = "email";
+
+    private static final String EMAIL_VERIFIED_CLAIM = "email_verified";
+
+    private static final String PREFERRED_USERNAME_CLAIM = "preferred_username";
+
+    private static final Logger logger = LoggerFactory.getLogger(PendingSharingInvitationRedeemer.class);
+
+    private final PendingSharingInvitationRepository repository;
+
+    private final AccessManager accessManager;
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public PendingSharingInvitationRedeemer(@Nonnull PendingSharingInvitationRepository repository,
+                                            @Nonnull AccessManager accessManager,
+                                            @Nonnull ObjectMapper objectMapper) {
+        this.repository = checkNotNull(repository);
+        this.accessManager = checkNotNull(accessManager);
+        this.objectMapper = checkNotNull(objectMapper);
+    }
+
+    /**
+     * Redeems every invitation matching {@code userId} (by lowercase user id) or, for email-shaped
+     * invitations, by a matching verified {@code email} claim in {@code jwt}.  Never throws.
+     */
+    public void redeem(@Nonnull UserId userId, @Nullable String jwt) {
+        if (userId.isGuest()) {
+            return;
+        }
+        try {
+            String usernameKey = normalizeKey(userId.id());
+            JwtEmailClaims claims = parseEmailClaims(jwt, usernameKey);
+
+            Set<String> lookupKeys = new HashSet<>();
+            lookupKeys.add(usernameKey);
+            if (claims.emailKey() != null) {
+                lookupKeys.add(claims.emailKey());
+            }
+
+            List<PendingSharingInvitation> matching = new ArrayList<>();
+            for (PendingSharingInvitation invitation : repository.findByPersonKeys(lookupKeys)) {
+                if (matches(invitation, usernameKey, claims)) {
+                    matching.add(invitation);
+                }
+            }
+            // Apply oldest first so that, when several invitations target the same project, the
+            // most recently created permission is the one that ends up in effect.
+            matching.sort(Comparator.comparing(PendingSharingInvitation::createdAt));
+            for (PendingSharingInvitation invitation : matching) {
+                redeemOne(userId, invitation);
+            }
+        } catch (RuntimeException e) {
+            logger.error("An unexpected error occurred while redeeming sharing invitations for user {}: {}",
+                         userId, e.toString());
+        }
+    }
+
+    private boolean matches(PendingSharingInvitation invitation, String usernameKey, JwtEmailClaims claims) {
+        String key = invitation.personKey();
+        if (PendingSharingInvitation.isEmailShaped(key)) {
+            if (claims.emailKey() == null || !key.equals(claims.emailKey())) {
+                return false;
+            }
+            if (!claims.emailVerified()) {
+                logger.warn("Not redeeming sharing invitation {} - its email matches the authenticated " +
+                            "user's email claim but email_verified is not true.", invitation);
+                return false;
+            }
+            return true;
+        }
+        return key.equals(usernameKey);
+    }
+
+    private void redeemOne(UserId userId, PendingSharingInvitation invitation) {
+        try {
+            // Claim the invitation by deleting it first; a zero deleted-count means another login (or
+            // an owner change) already consumed it, so there is nothing to grant.
+            if (repository.delete(invitation.projectId(), invitation.personKey()) == 0) {
+                return;
+            }
+            grant(userId, invitation);
+        } catch (RuntimeException e) {
+            // The invitation has already been claimed and is never re-inserted - a revoked invitation
+            // must not resurrect. Log loudly so an owner knows they may need to re-share.
+            logger.error("Failed to redeem sharing invitation {} for user {} - it has been consumed and " +
+                         "will NOT be restored: {}", invitation, userId, e.toString());
+        }
+    }
+
+    private void grant(UserId userId, PendingSharingInvitation invitation) {
+        ProjectResource projectResource = new ProjectResource(invitation.projectId());
+        Collection<RoleId> currentRoles = accessManager.getAssignedRoles(forUser(userId), projectResource);
+        Set<RoleId> newRoles = new HashSet<>(currentRoles);
+        newRoles.removeAll(Roles.SHARING_ROLE_IDS);
+        newRoles.addAll(Roles.fromSharingPermission(invitation.sharingPermission()));
+        accessManager.setAssignedRoles(forUser(userId), projectResource, newRoles);
+    }
+
+    private JwtEmailClaims parseEmailClaims(@Nullable String jwt, String usernameKey) {
+        if (jwt == null) {
+            return JwtEmailClaims.absent();
+        }
+        try {
+            String[] segments = jwt.split("\\.");
+            if (segments.length < 2) {
+                return JwtEmailClaims.absent();
+            }
+            JsonNode claims = objectMapper.readTree(decodePayload(segments[1]));
+            JsonNode emailNode = claims.get(EMAIL_CLAIM);
+            if (emailNode == null || emailNode.isNull() || emailNode.asText().isBlank()) {
+                return JwtEmailClaims.absent();
+            }
+            // Defensive subject binding: if the token names a preferred_username that does not match
+            // the acting user, ignore its email claim entirely. Today userId and jwt always come from
+            // the same ExecutionContext; this protects against a future call site pairing a userId
+            // with a mismatched token.
+            JsonNode preferredUsername = claims.get(PREFERRED_USERNAME_CLAIM);
+            if (preferredUsername != null && !preferredUsername.isNull()) {
+                String preferredUsernameKey = normalizeKey(preferredUsername.asText());
+                if (!preferredUsernameKey.isEmpty() && !preferredUsernameKey.equals(usernameKey)) {
+                    logger.warn("Ignoring the JWT email claim while redeeming sharing invitations: the " +
+                                "token's preferred_username '{}' does not match the acting user '{}'.",
+                                preferredUsernameKey, usernameKey);
+                    return JwtEmailClaims.absent();
+                }
+            }
+            return new JwtEmailClaims(normalizeKey(emailNode.asText()), isVerified(claims.get(EMAIL_VERIFIED_CLAIM)));
+        } catch (Exception e) {
+            // The token is already authenticated upstream; a payload we cannot parse simply means no
+            // usable email claim. Username-keyed invitations are unaffected.
+            logger.warn("Could not parse the JWT email claim while redeeming sharing invitations: {}",
+                        e.toString());
+            return JwtEmailClaims.absent();
+        }
+    }
+
+    private static byte[] decodePayload(String segment) {
+        try {
+            return Base64.getUrlDecoder().decode(segment);
+        } catch (IllegalArgumentException e) {
+            return Base64.getDecoder().decode(segment);
+        }
+    }
+
+    private static boolean isVerified(@Nullable JsonNode node) {
+        if (node == null || node.isNull()) {
+            return false;
+        }
+        if (node.isBoolean()) {
+            return node.booleanValue();
+        }
+        return node.isTextual() && "true".equalsIgnoreCase(node.asText().trim());
+    }
+
+    private record JwtEmailClaims(@Nullable String emailKey, boolean emailVerified) {
+
+        static JwtEmailClaims absent() {
+            return new JwtEmailClaims(null, false);
+        }
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRepository.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRepository.java
@@ -1,0 +1,46 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.persistence.Repository;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Stores {@link PendingSharingInvitation}s for people who were shared with before they had a
+ * WebProtege account.
+ */
+public interface PendingSharingInvitationRepository extends Repository {
+
+    /**
+     * Creates or replaces the invitation identified by its project and person key.  An existing
+     * invitation's original {@code createdAt} and {@code invitedBy} are preserved when it is
+     * replaced.
+     *
+     * @return {@code true} if this call inserted a brand new invitation, {@code false} if it
+     * replaced an existing one.
+     */
+    boolean upsert(@Nonnull PendingSharingInvitation invitation);
+
+    @Nonnull
+    List<PendingSharingInvitation> findByPersonKeys(@Nonnull Collection<String> personKeys);
+
+    @Nonnull
+    List<PendingSharingInvitation> findByProjectId(@Nonnull ProjectId projectId);
+
+    /**
+     * Deletes every invitation for the specified project whose person key is not in
+     * {@code personKeysToKeep}.
+     */
+    void deleteByProjectIdWherePersonKeyNotIn(@Nonnull ProjectId projectId,
+                                              @Nonnull Collection<String> personKeysToKeep);
+
+    /**
+     * Deletes the invitation identified by its project and person key.
+     *
+     * @return the number of invitations deleted (0 or 1), so a caller can treat a positive count as
+     * an atomic claim on the invitation.
+     */
+    long delete(@Nonnull ProjectId projectId, @Nonnull String personKey);
+}

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRepositoryImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRepositoryImpl.java
@@ -1,0 +1,171 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.ReplaceOptions;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.inject.ApplicationSingleton;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import javax.annotation.Nonnull;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static edu.stanford.protege.webprotege.sharing.PendingSharingInvitation.PERSON_KEY;
+import static edu.stanford.protege.webprotege.sharing.PendingSharingInvitation.PROJECT_ID;
+
+/**
+ * Mongo-backed {@link PendingSharingInvitationRepository}.
+ */
+@ApplicationSingleton
+public class PendingSharingInvitationRepositoryImpl implements PendingSharingInvitationRepository {
+
+    private static final String COLLECTION_NAME = "PendingSharingInvitations";
+
+    private static final String $NIN = "$nin";
+
+    private static final Logger logger = LoggerFactory.getLogger(PendingSharingInvitationRepositoryImpl.class);
+
+    private final MongoTemplate database;
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public PendingSharingInvitationRepositoryImpl(@Nonnull MongoTemplate database,
+                                                  @Nonnull ObjectMapper objectMapper) {
+        this.database = checkNotNull(database);
+        this.objectMapper = checkNotNull(objectMapper);
+    }
+
+    @Override
+    public void ensureIndexes() {
+        var collection = getCollection();
+        collection.createIndex(new Document(PROJECT_ID, 1).append(PERSON_KEY, 1),
+                               new IndexOptions().unique(true));
+        collection.createIndex(new Document(PERSON_KEY, 1));
+    }
+
+    @Override
+    public boolean upsert(@Nonnull PendingSharingInvitation invitation) {
+        return upsert(invitation, true);
+    }
+
+    private boolean upsert(@Nonnull PendingSharingInvitation invitation, boolean retryOnDuplicateKey) {
+        var filter = projectAndKeyFilter(invitation.projectId(), invitation.personKey());
+        var toStore = mergeWithExisting(invitation, filter);
+        var document = objectMapper.convertValue(toStore, Document.class);
+        try {
+            var result = getCollection().replaceOne(filter, document, new ReplaceOptions().upsert(true));
+            return result.getUpsertedId() != null;
+        } catch (MongoWriteException e) {
+            // A concurrent upsert of the same (projectId, personKey) can lose the race to insert and
+            // hit the unique index. Retry exactly once: the winning insert now exists, so the retry
+            // resolves to a plain replace rather than an insert.
+            if (retryOnDuplicateKey && e.getError().getCategory() == ErrorCategory.DUPLICATE_KEY) {
+                return upsert(invitation, false);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Preserves the original {@code createdAt} and {@code invitedBy} of an existing invitation so a
+     * re-save updates only the permission, leaving the invitation's identity and age intact.
+     */
+    private PendingSharingInvitation mergeWithExisting(PendingSharingInvitation invitation, Document filter) {
+        var existingDocument = getCollection().find(filter).first();
+        if (existingDocument == null) {
+            return invitation;
+        }
+        try {
+            var existing = objectMapper.convertValue(existingDocument, PendingSharingInvitation.class);
+            return new PendingSharingInvitation(invitation.projectId(),
+                                                invitation.personId(),
+                                                invitation.personKey(),
+                                                invitation.sharingPermission(),
+                                                existing.invitedBy(),
+                                                existing.createdAt());
+        } catch (RuntimeException e) {
+            logger.warn("Could not read the existing pending sharing invitation while upserting - " +
+                        "replacing it wholesale: {}", e.toString());
+            return invitation;
+        }
+    }
+
+    @Nonnull
+    @Override
+    public List<PendingSharingInvitation> findByPersonKeys(@Nonnull Collection<String> personKeys) {
+        // Tolerant read: skip (and warn about) any single corrupt document. This drives login-time
+        // redemption, where one unconvertable invitation must not block a user from redeeming all of
+        // their other invitations.
+        if (personKeys.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return read(new Document(PERSON_KEY, new Document("$in", new ArrayList<>(personKeys))), true);
+    }
+
+    @Nonnull
+    @Override
+    public List<PendingSharingInvitation> findByProjectId(@Nonnull ProjectId projectId) {
+        // Strict read: a per-document conversion failure propagates. This drives the sharing-page load
+        // and its merge; silently dropping a corrupt invitation would return a partial list that the
+        // next save's reconciliation would then interpret as removals of the dropped invitations.
+        return read(new Document(PROJECT_ID, projectId.id()), false);
+    }
+
+    @Override
+    public void deleteByProjectIdWherePersonKeyNotIn(@Nonnull ProjectId projectId,
+                                                     @Nonnull Collection<String> personKeysToKeep) {
+        var filter = new Document(PROJECT_ID, projectId.id())
+                .append(PERSON_KEY, new Document($NIN, new ArrayList<>(personKeysToKeep)));
+        getCollection().deleteMany(filter);
+    }
+
+    @Override
+    public long delete(@Nonnull ProjectId projectId, @Nonnull String personKey) {
+        var result = getCollection().deleteOne(projectAndKeyFilter(projectId, personKey));
+        return result.getDeletedCount();
+    }
+
+    /**
+     * Runs a query and converts each matching document. A failure reaching the database always
+     * propagates. A per-document conversion failure is skipped (with a warning) when {@code tolerant}
+     * is true, or propagates when it is false - see the two callers for why they differ.
+     */
+    private List<PendingSharingInvitation> read(Document filter, boolean tolerant) {
+        var result = new ArrayList<PendingSharingInvitation>();
+        try (var cursor = getCollection().find(filter).cursor()) {
+            while (cursor.hasNext()) {
+                var document = cursor.next();
+                if (tolerant) {
+                    try {
+                        result.add(objectMapper.convertValue(document, PendingSharingInvitation.class));
+                    } catch (RuntimeException e) {
+                        logger.warn("Skipping a pending sharing invitation document that could not be " +
+                                    "converted: {}", e.toString());
+                    }
+                } else {
+                    result.add(objectMapper.convertValue(document, PendingSharingInvitation.class));
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Document projectAndKeyFilter(ProjectId projectId, String personKey) {
+        return new Document(PROJECT_ID, projectId.id()).append(PERSON_KEY, personKey);
+    }
+
+    private MongoCollection<Document> getCollection() {
+        return database.getCollection(COLLECTION_NAME);
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl.java
@@ -12,12 +12,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import jakarta.inject.Inject;
+import java.time.Instant;
 import java.util.*;
 
 import static edu.stanford.protege.webprotege.authorization.Subject.forAnySignedInUser;
 import static edu.stanford.protege.webprotege.authorization.Subject.forUser;
 import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * Matthew Horridge
@@ -32,11 +32,19 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
 
     private final UserDetailsManager userLookup;
 
+    private final PendingSharingInvitationRepository pendingInvitationRepository;
+
+    private final SharingInvitationEmailer invitationEmailer;
+
     @Inject
     public ProjectSharingSettingsManagerImpl(AccessManager accessManager,
-                                             UserDetailsManager userLookup) {
+                                             UserDetailsManager userLookup,
+                                             PendingSharingInvitationRepository pendingInvitationRepository,
+                                             SharingInvitationEmailer invitationEmailer) {
         this.accessManager = accessManager;
         this.userLookup = userLookup;
+        this.pendingInvitationRepository = pendingInvitationRepository;
+        this.invitationEmailer = invitationEmailer;
     }
 
     @Override
@@ -44,37 +52,81 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
         List<SharingSetting> sharingSettings = new ArrayList<>();
         ProjectResource projectResource = new ProjectResource(projectId);
         Collection<Subject> subjects = accessManager.getSubjectsWithAccessToResource(projectResource);
+        // The keys of every active collaborator (their user id, plus their known local email) so that
+        // a pending invitation that has since become an active collaborator is not shown twice - the
+        // active entry wins on a key collision.
+        Set<String> activeKeys = new HashSet<>();
         subjects.stream()
                 .filter(s -> !s.isGuest())
                 .filter(s -> s.getUserName().isPresent())
                 .map(s -> UserId.valueOf(s.getUserName().get()))
                 .forEach(u -> {
                     Collection<RoleId> roles = accessManager.getAssignedRoles(forUser(u), projectResource);
-                    Roles.toSharingPermission(roles).ifPresent(
-                            p -> sharingSettings.add(new SharingSetting(PersonId.of(u), p)));
-
+                    Roles.toSharingPermission(roles).ifPresent(p -> {
+                        sharingSettings.add(new SharingSetting(PersonId.of(u), p));
+                        // Only a subject who produces a visible collaborator row suppresses a matching
+                        // pending row (via their id and their best-effort local email). A subject
+                        // holding only non-sharing roles must not suppress it - doing so would both
+                        // hide the pending row and let the next save's reconciliation delete the
+                        // owner's pending intent.
+                        activeKeys.add(PendingSharingInvitation.normalizeKey(u.id()));
+                        addKnownEmailKey(activeKeys, u);
+                    });
                 });
+        // A read failure here must propagate and fail the load: returning a partial list would let a
+        // subsequent save's reconciliation mistake the unseen pending invitations for removals.
+        for (PendingSharingInvitation invitation : pendingInvitationRepository.findByProjectId(projectId)) {
+            if (!activeKeys.contains(invitation.personKey())) {
+                sharingSettings.add(new SharingSetting(PersonId.get(invitation.personId()),
+                                                       invitation.sharingPermission()));
+            }
+        }
         Collection<RoleId> signedInUserRoles = accessManager.getAssignedRoles(forAnySignedInUser(), projectResource);
         Optional<SharingPermission> linkSharing = Roles.toSharingPermission(signedInUserRoles);
         return new ProjectSharingSettings(projectId, linkSharing, sharingSettings);
     }
 
+    private void addKnownEmailKey(Set<String> activeKeys, UserId userId) {
+        try {
+            userLookup.getEmail(userId)
+                      .map(PendingSharingInvitation::normalizeKey)
+                      .filter(key -> !key.isEmpty())
+                      .ifPresent(activeKeys::add);
+        } catch (RuntimeException e) {
+            // Best effort only - if we cannot fetch the email we simply fall back to showing the
+            // pending row, which is harmless.
+            logger.warn("Could not look up the email for active collaborator {} while merging pending " +
+                        "sharing invitations: {}", userId, e.toString());
+        }
+    }
 
     @Override
     public void setProjectSharingSettings(@Nonnull UserId actingUserId, @Nonnull ProjectSharingSettings settings) {
         ProjectId projectId = settings.getProjectId();
         ProjectResource projectResource = new ProjectResource(projectId);
 
-        Map<PersonId, SharingSetting> map = settings.getSharingSettings().stream()
-                                                    .collect(toMap(SharingSetting::getPersonId, s -> s, (s1, s2) -> s1));
+        // Preserve the submitted order (keeping the first occurrence of any exactly-duplicated
+        // PersonId) so that de-duplicating confirmed-absent entries by normalized key is
+        // deterministic: the first-submitted entry wins on a normalized-key collision.
+        Map<PersonId, SharingSetting> map = new LinkedHashMap<>();
+        for (SharingSetting setting : settings.getSharingSettings()) {
+            map.putIfAbsent(setting.getPersonId(), setting);
+        }
 
-        // Phase 1: resolve every submitted entry to a UserId first. A lookup failure (an infra
-        // error, or the duplicate-match RuntimeException) for one entry must never affect any
-        // other person's access - keep processing the rest, remember the first failure (with
-        // later ones suppressed onto it), and rethrow it at the end. A confirmed-absent
+        // Phase 1: classify every submitted entry as resolved / confirmed-absent / failed. A lookup
+        // failure (an infra error, or the duplicate-match RuntimeException) for one entry must never
+        // affect any other person's access - keep processing the rest, remember the first failure
+        // (with later ones suppressed onto it), and rethrow it at the end. A confirmed-absent
         // (Optional.empty()) result is not a failure: it carries no identity ambiguity, so it must
-        // not gate the removal step below.
+        // not gate the removal step below, and it becomes a pending invitation.
+        //
+        // This phase performs NO writes - not to the access manager, and not to the pending-invitation
+        // store. All store writes and email dispatch happen only after Phases 2-5 succeed, so a phase
+        // failure leaves the pending store untouched and a retried save regenerates the same
+        // first-time-invitation email signal.
         Map<UserId, SharingPermission> desiredByUser = new HashMap<>();
+        Map<String, PendingSharingInvitation> confirmedAbsentByKey = new LinkedHashMap<>();
+        Set<String> failedKeys = new HashSet<>();
         RuntimeException lookupFailure = null;
         for (SharingSetting setting : map.values()) {
             PersonId personId = setting.getPersonId();
@@ -92,6 +144,10 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
                 } else {
                     lookupFailure.addSuppressed(e);
                 }
+                String failedKey = PendingSharingInvitation.normalizeKey(personId.getId());
+                if (!failedKey.isEmpty()) {
+                    failedKeys.add(failedKey);
+                }
                 continue;
             }
             if (userId.isPresent()) {
@@ -106,11 +162,7 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
                 }
             }
             else {
-                logger.warn("Could not resolve the user for a project sharing setting (person id '{}', " +
-                            "project {}) - their access was not updated.  An email invitation needs to " +
-                            "be sent.", personId.getId(), projectId);
-                // TODO
-                // We need to send the user an email invitation
+                collectConfirmedAbsent(projectId, actingUserId, confirmedAbsentByKey, setting);
             }
         }
 
@@ -180,8 +232,87 @@ public class ProjectSharingSettingsManagerImpl implements ProjectSharingSettings
             throw e;
         }
 
+        // The access-manager phases succeeded. Only now update the pending-invitation store and
+        // dispatch any first-time-invitation emails; neither step may fail the save, and neither may
+        // swallow the recorded lookup failure that must still be rethrown below.
+        applyPendingInvitations(projectId, confirmedAbsentByKey, failedKeys);
+
         if (lookupFailure != null) {
             throw lookupFailure;
+        }
+    }
+
+    private void collectConfirmedAbsent(ProjectId projectId,
+                                        UserId actingUserId,
+                                        Map<String, PendingSharingInvitation> confirmedAbsentByKey,
+                                        SharingSetting setting) {
+        PersonId personId = setting.getPersonId();
+        String key = PendingSharingInvitation.normalizeKey(personId.getId());
+        if (key.isEmpty()) {
+            logger.warn("Ignoring a project sharing setting whose person id '{}' normalizes to an empty " +
+                        "key for project {}.", personId.getId(), projectId);
+            return;
+        }
+        if (confirmedAbsentByKey.containsKey(key)) {
+            logger.warn("More than one submitted sharing setting for project {} resolves to the same " +
+                        "pending-invitation key ('{}') - only the first one will be stored.", projectId, key);
+            return;
+        }
+        confirmedAbsentByKey.put(key, new PendingSharingInvitation(projectId,
+                                                                   personId.getId(),
+                                                                   personId.getId(),
+                                                                   setting.getSharingPermission(),
+                                                                   actingUserId,
+                                                                   Instant.now()));
+    }
+
+    /**
+     * Upserts the confirmed-absent invitations, reconciles the project's pending invitations against
+     * what was submitted, and dispatches an email for each brand-new email-shaped invitation. Runs
+     * only after the access-manager phases have succeeded, and never throws - a store or mail failure
+     * here must not fail the save.
+     */
+    private void applyPendingInvitations(ProjectId projectId,
+                                         Map<String, PendingSharingInvitation> confirmedAbsentByKey,
+                                         Set<String> failedKeys) {
+        // Reconcile FIRST, in its own guard: it depends only on the keys computed in Phase 1, so a
+        // later upsert failure must never be able to skip the removal of invitations the owner
+        // dropped or that now resolve to a real user. Keep only the invitations we just (re)confirmed
+        // as absent, plus those whose lookup failed this call (we cannot safely decide about them).
+        try {
+            Set<String> keepKeys = new HashSet<>(confirmedAbsentByKey.keySet());
+            keepKeys.addAll(failedKeys);
+            pendingInvitationRepository.deleteByProjectIdWherePersonKeyNotIn(projectId, keepKeys);
+        }
+        catch (RuntimeException e) {
+            logger.error("Could not reconcile the pending sharing invitations for project {}: {}",
+                         projectId, e.toString());
+        }
+        // Then upsert each confirmed-absent invitation independently, so one failed upsert does not
+        // skip the others; collect the ones that were freshly inserted so only they are emailed.
+        List<PendingSharingInvitation> freshInserts = new ArrayList<>();
+        for (PendingSharingInvitation invitation : confirmedAbsentByKey.values()) {
+            try {
+                if (pendingInvitationRepository.upsert(invitation)) {
+                    freshInserts.add(invitation);
+                }
+            }
+            catch (RuntimeException e) {
+                logger.error("Could not store the pending sharing invitation for '{}' in project {}: {}",
+                             invitation.personId(), projectId, e.toString());
+            }
+        }
+        // Email only brand-new invitations (never a re-save), and only when the id is email-shaped.
+        try {
+            for (PendingSharingInvitation invitation : freshInserts) {
+                if (PendingSharingInvitation.isEmailShaped(invitation.personKey())) {
+                    invitationEmailer.sendInvitationEmail(projectId, invitation.personId(), invitation.invitedBy());
+                }
+            }
+        }
+        catch (RuntimeException e) {
+            logger.error("Could not dispatch sharing invitation emails for project {}: {}",
+                         projectId, e.toString());
         }
     }
 

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/SharingInvitationEmailTemplate.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/SharingInvitationEmailTemplate.java
@@ -1,0 +1,15 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Qualifier for the template file used to render sharing-invitation emails.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SharingInvitationEmailTemplate {
+
+}

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/SharingInvitationEmailer.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/SharingInvitationEmailer.java
@@ -1,0 +1,144 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import com.google.common.collect.ImmutableMap;
+import edu.stanford.protege.webprotege.app.PlaceUrl;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import edu.stanford.protege.webprotege.filemanager.FileContents;
+import edu.stanford.protege.webprotege.mail.SendMail;
+import edu.stanford.protege.webprotege.project.ProjectDetailsRepository;
+import edu.stanford.protege.webprotege.project.ProjectDetails;
+import edu.stanford.protege.webprotege.templates.TemplateEngine;
+import edu.stanford.protege.webprotege.templates.TemplateObjectsBuilder;
+import edu.stanford.protege.webprotege.user.UserDetails;
+import edu.stanford.protege.webprotege.user.UserDetailsManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Sends an email to a person who has been shared with but does not yet have a WebProtege account,
+ * inviting them to sign in.  Emails are dispatched on a single-thread executor so a slow or failing
+ * mail server never blocks or breaks the save that triggered the invitation.
+ */
+public class SharingInvitationEmailer {
+
+    private static final String INVITER = "inviter";
+
+    private static final Logger logger = LoggerFactory.getLogger(SharingInvitationEmailer.class);
+
+    private final ProjectDetailsRepository projectDetailsRepository;
+
+    private final UserDetailsManager userDetailsManager;
+
+    private final FileContents templateFile;
+
+    private final TemplateEngine templateEngine;
+
+    private final PlaceUrl placeUrl;
+
+    private final SendMail sendMail;
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+        thread.setName(thread.getName().replace("thread", "sharing-invitation-email-thread"));
+        return thread;
+    });
+
+    @Inject
+    public SharingInvitationEmailer(@Nonnull ProjectDetailsRepository projectDetailsRepository,
+                                    @Nonnull UserDetailsManager userDetailsManager,
+                                    @Nonnull FileContents templateFile,
+                                    @Nonnull TemplateEngine templateEngine,
+                                    @Nonnull PlaceUrl placeUrl,
+                                    @Nonnull SendMail sendMail) {
+        this.projectDetailsRepository = checkNotNull(projectDetailsRepository);
+        this.userDetailsManager = checkNotNull(userDetailsManager);
+        this.templateFile = checkNotNull(templateFile);
+        this.templateEngine = checkNotNull(templateEngine);
+        this.placeUrl = checkNotNull(placeUrl);
+        this.sendMail = checkNotNull(sendMail);
+    }
+
+    /**
+     * Submits an invitation email for asynchronous delivery.  Returns immediately; delivery
+     * failures are logged but never surfaced to the caller.
+     *
+     * @param projectId         The project the person was invited to.
+     * @param recipientEmail    The email address as the owner typed it.
+     * @param invitedBy         The user who shared the project.
+     */
+    public void sendInvitationEmail(@Nonnull ProjectId projectId,
+                                    @Nonnull String recipientEmail,
+                                    @Nonnull UserId invitedBy) {
+        executor.submit(() -> {
+            try {
+                doSendInvitationEmail(projectId, recipientEmail, invitedBy);
+            } catch (RuntimeException e) {
+                logger.error("Could not send a sharing invitation email for project {}: {}",
+                             projectId, e.toString());
+            }
+        });
+    }
+
+    private void doSendInvitationEmail(ProjectId projectId, String recipientEmail, UserId invitedBy) {
+        // Structural guard on the template file rather than string-matching FileContents' error text:
+        // skip the send if the file is absent or its contents are empty.
+        if (!templateFile.exists()) {
+            logger.error("Not sending a sharing invitation email for project {} - the email template " +
+                         "file does not exist.", projectId);
+            return;
+        }
+        String template = templateFile.getContents();
+        if (template.isBlank()) {
+            logger.error("Not sending a sharing invitation email for project {} - the email template " +
+                         "is empty.", projectId);
+            return;
+        }
+        String recipient = recipientEmail.trim();
+        // Sanitize the values that flow into the (unescaped) subject header - a display name or project
+        // name carrying a CR/LF could otherwise inject headers. The Mustache body is HTML-escaped.
+        String projectName = sanitizeForHeader(projectDetailsRepository.findOne(projectId)
+                                                                       .map(ProjectDetails::getDisplayName)
+                                                                       .orElse("a project"));
+        String inviterName = sanitizeForHeader(userDetailsManager.getUserDetails(invitedBy)
+                                                                 .map(UserDetails::getDisplayName)
+                                                                 .orElse(invitedBy.id()));
+        ImmutableMap<String, Object> objects =
+                TemplateObjectsBuilder.builder()
+                                      .withProjectDisplayName(projectName)
+                                      .withApplicationUrl(placeUrl.getApplicationUrl())
+                                      .with(INVITER, inviterName)
+                                      .build();
+        String body = templateEngine.populateTemplate(template, objects);
+        String subject = String.format("[%s] You have been invited to collaborate on WebProtege", projectName);
+        sendMail.sendMail(List.of(recipient), subject, body);
+    }
+
+    private static String sanitizeForHeader(String value) {
+        // Remove CR/LF and any other control characters so they cannot break out of the subject line.
+        return value.replaceAll("\\p{Cntrl}", "");
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/user/GetAuthenticatedUserDetailsActionHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/GetAuthenticatedUserDetailsActionHandler.java
@@ -8,6 +8,9 @@ import edu.stanford.protege.webprotege.dispatch.RequestContext;
 import edu.stanford.protege.webprotege.dispatch.RequestValidator;
 import edu.stanford.protege.webprotege.dispatch.validators.NullValidator;
 import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import edu.stanford.protege.webprotege.sharing.PendingSharingInvitationRedeemer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -20,14 +23,20 @@ import java.util.Optional;
  */
 public class GetAuthenticatedUserDetailsActionHandler implements ApplicationActionHandler<GetAuthenticatedUserDetailsRequest, GetAuthenticatedUserDetailsResponse> {
 
+    private static final Logger logger = LoggerFactory.getLogger(GetAuthenticatedUserDetailsActionHandler.class);
+
     private final AccessManager accessManager;
 
     private final UserDetailsManager userDetailsManager;
 
+    private final PendingSharingInvitationRedeemer invitationRedeemer;
+
     public GetAuthenticatedUserDetailsActionHandler(AccessManager accessManager,
-                                                    UserDetailsManager userDetailsManager) {
+                                                    UserDetailsManager userDetailsManager,
+                                                    PendingSharingInvitationRedeemer invitationRedeemer) {
         this.accessManager = accessManager;
         this.userDetailsManager = userDetailsManager;
+        this.invitationRedeemer = invitationRedeemer;
     }
 
     @Nonnull
@@ -54,6 +63,15 @@ public class GetAuthenticatedUserDetailsActionHandler implements ApplicationActi
                                                            Collections.emptySet());
         }
         else {
+            // Redeem any pending sharing invitations for this user before computing their capability
+            // closure, so freshly granted project access is reflected in this same response. This must
+            // never break login, so any failure is caught and logged rather than propagated.
+            try {
+                invitationRedeemer.redeem(userId, executionContext.jwt());
+            } catch (RuntimeException e) {
+                logger.error("Could not redeem pending sharing invitations for user {}: {}",
+                             userId, e.toString());
+            }
             var userDetails = userDetailsManager.getUserDetails(userId)
                                                 .orElse(UserDetails.getUserDetails(userId,
                                                                                    userId.id(), Optional.empty()));

--- a/src/main/resources/templates/sharing-invitation-email-template.html
+++ b/src/main/resources/templates/sharing-invitation-email-template.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+    <style>
+        .main {
+            font-family: Helvetica, Arial, sans-serif;
+        }
+        .inviter {
+            font-weight: bold;
+        }
+        .projectName {
+            font-weight: bold;
+        }
+        .footer {
+            padding-top: 20px;
+            font-size: 10px;
+            color: #707070;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+<div class="main">
+    <div>
+        <span class="inviter">{{inviter}}</span> has invited you to collaborate on the project <span class="projectName">{{project.displayName}}</span> in WebProtege.
+    </div>
+    <div>
+        Sign in to <a href="{{{application.url}}}">WebProtege</a> with this email address to accept the invitation and start collaborating.
+    </div>
+    <div class="footer">
+        You received this email because someone invited you to a project on <a href="{{{application.url}}}">WebProtege</a>.
+    </div>
+</div>
+</body></html>

--- a/src/main/resources/templates/sharing-invitation-email-template.html
+++ b/src/main/resources/templates/sharing-invitation-email-template.html
@@ -24,7 +24,7 @@
         <span class="inviter">{{inviter}}</span> has invited you to collaborate on the project <span class="projectName">{{project.displayName}}</span> in WebProtege.
     </div>
     <div>
-        Sign in to <a href="{{{application.url}}}">WebProtege</a> with this email address to accept the invitation and start collaborating.
+        Create an account in <a href="{{{application.url}}}">WebProtege</a> to accept the invitation and start collaborating.
     </div>
     <div class="footer">
         You received this email because someone invited you to a project on <a href="{{{application.url}}}">WebProtege</a>.

--- a/src/test/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRedeemer_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRedeemer_TestCase.java
@@ -1,0 +1,309 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.stanford.protege.webprotege.MockingUtils;
+import edu.stanford.protege.webprotege.access.AccessManager;
+import edu.stanford.protege.webprotege.authorization.ProjectResource;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+
+import static edu.stanford.protege.webprotege.authorization.Subject.forUser;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link PendingSharingInvitationRedeemer}.  Locks in the deliberately narrow trust model
+ * (email-shaped keys only ever redeem against a matching, verified email claim - never the
+ * username), the JWT payload decoding edge cases, createdAt ordering and the fault-isolation /
+ * never-throws guarantees.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class PendingSharingInvitationRedeemer_TestCase {
+
+    private static final String HEADER = base64Url("{\"alg\":\"none\"}");
+
+    @Mock
+    private PendingSharingInvitationRepository repository;
+
+    @Mock
+    private AccessManager accessManager;
+
+    private PendingSharingInvitationRedeemer redeemer;
+
+    private final ProjectId projectId = MockingUtils.mockProjectId();
+
+    private final ProjectResource projectResource = new ProjectResource(projectId);
+
+    private final UserId userId = UserId.valueOf("jdoe");
+
+    @BeforeEach
+    public void setUp() {
+        redeemer = new PendingSharingInvitationRedeemer(repository, accessManager, new ObjectMapper());
+    }
+
+    private PendingSharingInvitation invitation(String key, SharingPermission permission) {
+        return invitation(projectId, key, permission, Instant.now());
+    }
+
+    private PendingSharingInvitation invitation(ProjectId projectId,
+                                                String key,
+                                                SharingPermission permission,
+                                                Instant createdAt) {
+        return new PendingSharingInvitation(projectId, key, key, permission, MockingUtils.mockUserId(), createdAt);
+    }
+
+    @Test
+    public void shouldGrantAndConsumeUsernameKeyedInvitation() {
+        PendingSharingInvitation invitation = invitation("jdoe", SharingPermission.VIEW);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "jdoe")).thenReturn(1L);
+
+        redeemer.redeem(userId, jwt("{}"));
+
+        verify(repository).delete(projectId, "jdoe");
+        verify(accessManager).setAssignedRoles(eq(forUser(userId)), eq(projectResource),
+                                               eq(new HashSet<>(Roles.fromSharingPermission(SharingPermission.VIEW))));
+    }
+
+    @Test
+    public void shouldGrantEmailKeyedInvitationWhenEmailClaimMatchesAndIsVerified() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.MANAGE);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "new@x.org")).thenReturn(1L);
+
+        redeemer.redeem(userId, jwt("{\"email\":\"New@x.org\",\"email_verified\":true}"));
+
+        verify(repository).delete(projectId, "new@x.org");
+        verify(accessManager).setAssignedRoles(eq(forUser(userId)), eq(projectResource),
+                                               eq(new HashSet<>(Roles.fromSharingPermission(SharingPermission.MANAGE))));
+    }
+
+    @Test
+    public void shouldGrantEmailKeyedInvitationWhenEmailVerifiedIsStringTrue() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.EDIT);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "new@x.org")).thenReturn(1L);
+
+        redeemer.redeem(userId, jwt("{\"email\":\"new@x.org\",\"email_verified\":\"true\"}"));
+
+        verify(repository).delete(projectId, "new@x.org");
+        verify(accessManager).setAssignedRoles(eq(forUser(userId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldNotRedeemEmailKeyedInvitationWhenEmailVerifiedIsFalse() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.MANAGE);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+
+        redeemer.redeem(userId, jwt("{\"email\":\"new@x.org\",\"email_verified\":false}"));
+
+        verify(repository, never()).delete(any(), anyString());
+        verify(accessManager, never()).setAssignedRoles(any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotRedeemEmailKeyedInvitationWhenEmailVerifiedClaimIsAbsent() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.MANAGE);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+
+        redeemer.redeem(userId, jwt("{\"email\":\"new@x.org\"}"));
+
+        verify(repository, never()).delete(any(), anyString());
+        verify(accessManager, never()).setAssignedRoles(any(), any(), any());
+    }
+
+    @Test
+    public void shouldNeverRedeemEmailShapedKeyViaTheUsernamePath() {
+        // Deployment reality: registrationEmailAsUsername=true, so the username can equal the email.
+        // An email-shaped invitation must still never be redeemed by the username alone.
+        UserId emailUsername = UserId.valueOf("new@x.org");
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.MANAGE);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+
+        redeemer.redeem(emailUsername, jwt("{}"));
+
+        verify(repository, never()).delete(any(), anyString());
+        verify(accessManager, never()).setAssignedRoles(any(), any(), any());
+    }
+
+    @Test
+    public void shouldApplyMatchingInvitationsInAscendingCreatedAtOrder() {
+        Instant earlier = Instant.parse("2024-01-01T00:00:00Z");
+        Instant later = Instant.parse("2024-06-01T00:00:00Z");
+        // Same project, two different keys that both match this user; the newer one must be applied
+        // last so its permission is the one that ends up in effect.
+        PendingSharingInvitation olderByUsername = invitation(projectId, "jdoe", SharingPermission.VIEW, earlier);
+        PendingSharingInvitation newerByEmail = invitation(projectId, "new@x.org", SharingPermission.MANAGE, later);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(newerByEmail, olderByUsername));
+        when(repository.delete(eq(projectId), anyString())).thenReturn(1L);
+
+        redeemer.redeem(userId, jwt("{\"email\":\"new@x.org\",\"email_verified\":true}"));
+
+        InOrder inOrder = inOrder(accessManager);
+        inOrder.verify(accessManager).setAssignedRoles(eq(forUser(userId)), eq(projectResource),
+                                                       eq(new HashSet<>(Roles.fromSharingPermission(SharingPermission.VIEW))));
+        inOrder.verify(accessManager).setAssignedRoles(eq(forUser(userId)), eq(projectResource),
+                                                       eq(new HashSet<>(Roles.fromSharingPermission(SharingPermission.MANAGE))));
+    }
+
+    @Test
+    public void shouldIgnoreEmailClaimWhenPreferredUsernameDoesNotMatchTheActingUser() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.MANAGE);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+
+        // The token names a preferred_username other than the acting userId, so its email claim is
+        // ignored and the email-shaped invitation is not redeemed.
+        redeemer.redeem(userId,
+                        jwt("{\"email\":\"new@x.org\",\"email_verified\":true,\"preferred_username\":\"someone-else\"}"));
+
+        verify(repository, never()).delete(any(), anyString());
+        verify(accessManager, never()).setAssignedRoles(any(), any(), any());
+    }
+
+    @Test
+    public void shouldRedeemWhenPreferredUsernameMatchesTheActingUser() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.MANAGE);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "new@x.org")).thenReturn(1L);
+
+        redeemer.redeem(userId,
+                        jwt("{\"email\":\"new@x.org\",\"email_verified\":true,\"preferred_username\":\"jdoe\"}"));
+
+        verify(repository).delete(projectId, "new@x.org");
+    }
+
+    @Test
+    public void shouldBeANoOpForTheGuestUser() {
+        redeemer.redeem(UserId.getGuest(), jwt("{\"email\":\"new@x.org\",\"email_verified\":true}"));
+
+        verifyNoInteractions(repository, accessManager);
+    }
+
+    @Test
+    public void shouldRedeemWhenPayloadUsesPaddedUrlSafeBase64() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.EDIT);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "new@x.org")).thenReturn(1L);
+
+        String payload = Base64.getUrlEncoder()
+                               .encodeToString("{\"email\":\"new@x.org\",\"email_verified\":true}"
+                                                       .getBytes(StandardCharsets.UTF_8));
+        redeemer.redeem(userId, HEADER + "." + payload + ".sig");
+
+        verify(repository).delete(projectId, "new@x.org");
+    }
+
+    @Test
+    public void shouldRedeemWhenPayloadUsesStandardBase64() {
+        PendingSharingInvitation invitation = invitation("new@x.org", SharingPermission.EDIT);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "new@x.org")).thenReturn(1L);
+
+        redeemer.redeem(userId, standardBase64Jwt());
+
+        verify(repository).delete(projectId, "new@x.org");
+    }
+
+    @Test
+    public void shouldSwallowUnparseableJwtButStillRedeemUsernameKeyedInvitation() {
+        PendingSharingInvitation invitation = invitation("jdoe", SharingPermission.VIEW);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "jdoe")).thenReturn(1L);
+
+        assertDoesNotThrow(() -> redeemer.redeem(userId, "not-a-valid-jwt"));
+
+        verify(repository).delete(projectId, "jdoe");
+        verify(accessManager).setAssignedRoles(eq(forUser(userId)), eq(projectResource), any());
+    }
+
+    @Test
+    public void shouldNotGrantWhenTheInvitationWasAlreadyClaimed() {
+        PendingSharingInvitation invitation = invitation("jdoe", SharingPermission.VIEW);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        // Another login (or an owner change) already consumed the invitation.
+        when(repository.delete(projectId, "jdoe")).thenReturn(0L);
+
+        redeemer.redeem(userId, jwt("{}"));
+
+        verify(accessManager, never()).setAssignedRoles(any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotThrowNorReInsertWhenAGrantFails() {
+        PendingSharingInvitation invitation = invitation("jdoe", SharingPermission.VIEW);
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(invitation));
+        when(repository.delete(projectId, "jdoe")).thenReturn(1L);
+        doThrow(new RuntimeException("grant failed")).when(accessManager)
+                                                     .setAssignedRoles(eq(forUser(userId)), eq(projectResource), any());
+
+        assertDoesNotThrow(() -> redeemer.redeem(userId, jwt("{}")));
+
+        // A consumed invitation is never restored, even when the grant fails.
+        verify(repository, never()).upsert(any());
+    }
+
+    @Test
+    public void shouldIsolateAFailedInvitationFromTheRemainingOnes() {
+        ProjectId otherProjectId = MockingUtils.mockProjectId();
+        PendingSharingInvitation failing = invitation(projectId, "jdoe", SharingPermission.VIEW, Instant.parse("2024-01-01T00:00:00Z"));
+        PendingSharingInvitation succeeding = invitation(otherProjectId, "jdoe", SharingPermission.EDIT, Instant.parse("2024-02-01T00:00:00Z"));
+        when(repository.findByPersonKeys(any())).thenReturn(List.of(failing, succeeding));
+        when(repository.delete(eq(projectId), eq("jdoe"))).thenReturn(1L);
+        when(repository.delete(eq(otherProjectId), eq("jdoe"))).thenReturn(1L);
+        doThrow(new RuntimeException("grant failed")).when(accessManager)
+                                                     .setAssignedRoles(eq(forUser(userId)), eq(projectResource), any());
+
+        redeemer.redeem(userId, jwt("{}"));
+
+        // The failure on the first invitation must not prevent the second from being granted.
+        verify(accessManager).setAssignedRoles(eq(forUser(userId)), eq(new ProjectResource(otherProjectId)), any());
+    }
+
+    private static String jwt(String payloadJson) {
+        return HEADER + "." + base64Url(payloadJson) + ".sig";
+    }
+
+    private static String base64Url(String value) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Builds a JWT whose payload is encoded with the standard (non-URL-safe) Base64 alphabet, growing
+     * a filler claim until the encoded payload actually contains a '+' or '/' - characters the
+     * URL-safe decoder rejects, so the redeemer must fall back to the standard decoder.
+     */
+    private static String standardBase64Jwt() {
+        for (int i = 0; i < 256; i++) {
+            String json = "{\"email\":\"new@x.org\",\"email_verified\":true,\"pad\":\""
+                    + "ÿ".repeat(i) + "\"}";
+            String payload = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+            if (payload.contains("+") || payload.contains("/")) {
+                return HEADER + "." + payload + ".sig";
+            }
+        }
+        throw new IllegalStateException("Could not build a standard-base64 payload containing '+' or '/'");
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRepositoryImpl_IT.java
+++ b/src/test/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitationRepositoryImpl_IT.java
@@ -1,0 +1,189 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import edu.stanford.protege.webprotege.MongoTestExtension;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SpringBootTest(properties = {"webprotege.rabbitmq.commands-subscribe=false"})
+@ExtendWith({MongoTestExtension.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class PendingSharingInvitationRepositoryImpl_IT {
+
+    private static final String COLLECTION_NAME = "PendingSharingInvitations";
+
+    @Autowired
+    private PendingSharingInvitationRepository repository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    private final ProjectId projectId = ProjectId.valueOf("12345678-1234-1234-1234-123456789abc");
+
+    private final ProjectId otherProjectId = ProjectId.valueOf("12345678-1234-1234-1234-123456789def");
+
+    private final UserId invitedBy = UserId.valueOf("owner");
+
+    private final Instant createdAt = Instant.parse("2024-01-01T00:00:00Z");
+
+    @BeforeEach
+    public void setUp() {
+        repository.ensureIndexes();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mongoTemplate.getCollection(COLLECTION_NAME).drop();
+    }
+
+    private PendingSharingInvitation invitation(ProjectId projectId,
+                                                String personId,
+                                                SharingPermission permission,
+                                                UserId invitedBy,
+                                                Instant createdAt) {
+        return new PendingSharingInvitation(projectId, personId, personId, permission, invitedBy, createdAt);
+    }
+
+    @Test
+    public void shouldReportInsertOnFirstUpsertAndReplaceOnSecond() {
+        assertThat(repository.upsert(invitation(projectId, "new@x.org", SharingPermission.VIEW, invitedBy, createdAt)),
+                   is(true));
+        assertThat(mongoTemplate.getCollection(COLLECTION_NAME).countDocuments(), is(1L));
+
+        assertThat(repository.upsert(invitation(projectId, "new@x.org", SharingPermission.EDIT, invitedBy, createdAt)),
+                   is(false));
+        assertThat(mongoTemplate.getCollection(COLLECTION_NAME).countDocuments(), is(1L));
+    }
+
+    @Test
+    public void shouldPreserveOriginalCreatedAtAndInvitedByWhenReplacing() {
+        repository.upsert(invitation(projectId, "new@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+
+        Instant laterCreatedAt = Instant.parse("2025-01-01T00:00:00Z");
+        UserId laterInviter = UserId.valueOf("someone-else");
+        repository.upsert(invitation(projectId, "new@x.org", SharingPermission.EDIT, laterInviter, laterCreatedAt));
+
+        List<PendingSharingInvitation> found = repository.findByProjectId(projectId);
+        assertThat(found, hasSize(1));
+        PendingSharingInvitation invitation = found.get(0);
+        // The permission is updated, but the original identity and age of the invitation are kept.
+        assertThat(invitation.sharingPermission(), is(SharingPermission.EDIT));
+        assertThat(invitation.invitedBy(), is(invitedBy));
+        assertThat(invitation.createdAt(), is(createdAt));
+    }
+
+    @Test
+    public void shouldFindByProjectId() {
+        repository.upsert(invitation(projectId, "a@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+        repository.upsert(invitation(projectId, "b@x.org", SharingPermission.EDIT, invitedBy, createdAt));
+        repository.upsert(invitation(otherProjectId, "c@x.org", SharingPermission.MANAGE, invitedBy, createdAt));
+
+        assertThat(repository.findByProjectId(projectId), hasSize(2));
+        assertThat(repository.findByProjectId(otherProjectId), hasSize(1));
+    }
+
+    @Test
+    public void shouldFindByPersonKeys() {
+        repository.upsert(invitation(projectId, "a@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+        repository.upsert(invitation(otherProjectId, "a@x.org", SharingPermission.EDIT, invitedBy, createdAt));
+        repository.upsert(invitation(projectId, "b@x.org", SharingPermission.MANAGE, invitedBy, createdAt));
+
+        List<PendingSharingInvitation> found = repository.findByPersonKeys(Set.of("a@x.org"));
+        assertThat(found, hasSize(2));
+    }
+
+    @Test
+    public void shouldReturnNothingForEmptyPersonKeys() {
+        repository.upsert(invitation(projectId, "a@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+
+        assertThat(repository.findByPersonKeys(Set.of()), hasSize(0));
+    }
+
+    @Test
+    public void shouldDeleteInvitationsWhosePersonKeyIsNotKept() {
+        repository.upsert(invitation(projectId, "keep@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+        repository.upsert(invitation(projectId, "drop@x.org", SharingPermission.EDIT, invitedBy, createdAt));
+        repository.upsert(invitation(otherProjectId, "other@x.org", SharingPermission.MANAGE, invitedBy, createdAt));
+
+        repository.deleteByProjectIdWherePersonKeyNotIn(projectId, Set.of("keep@x.org"));
+
+        List<PendingSharingInvitation> remaining = repository.findByProjectId(projectId);
+        assertThat(remaining, hasSize(1));
+        assertThat(remaining.get(0).personKey(), is("keep@x.org"));
+        // A different project's invitations are untouched.
+        assertThat(repository.findByProjectId(otherProjectId), hasSize(1));
+    }
+
+    @Test
+    public void shouldDeleteAllPendingInvitationsForProjectWhenNoKeysAreKept() {
+        repository.upsert(invitation(projectId, "a@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+        repository.upsert(invitation(projectId, "b@x.org", SharingPermission.EDIT, invitedBy, createdAt));
+
+        repository.deleteByProjectIdWherePersonKeyNotIn(projectId, Set.of());
+
+        assertThat(repository.findByProjectId(projectId), hasSize(0));
+    }
+
+    @Test
+    public void shouldReportDeletedCountAsAClaim() {
+        repository.upsert(invitation(projectId, "new@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+
+        assertThat(repository.delete(projectId, "new@x.org"), is(1L));
+        // A second delete of the same invitation is a no-op - the claim has already been taken.
+        assertThat(repository.delete(projectId, "new@x.org"), is(0L));
+    }
+
+    @Test
+    public void findByProjectIdShouldPropagateAConversionFailureWhileFindByPersonKeysSkipsIt() {
+        repository.upsert(invitation(projectId, "good@x.org", SharingPermission.VIEW, invitedBy, createdAt));
+        // A malformed document (missing required fields) that cannot be converted to the record.
+        mongoTemplate.getCollection(COLLECTION_NAME).insertOne(
+                new Document(PendingSharingInvitation.PROJECT_ID, projectId.id())
+                        .append(PendingSharingInvitation.PERSON_KEY, "corrupt@x.org"));
+
+        // The strict page-load read fails rather than silently dropping the corrupt document.
+        assertThrows(RuntimeException.class, () -> repository.findByProjectId(projectId));
+
+        // The tolerant login-time read skips the corrupt document and still returns the good one.
+        List<PendingSharingInvitation> found = repository.findByPersonKeys(Set.of("good@x.org", "corrupt@x.org"));
+        assertThat(found, hasSize(1));
+        assertThat(found.get(0).personKey(), is("good@x.org"));
+    }
+
+    @Test
+    public void shouldEnforceTheUniqueIndexOnProjectIdAndPersonKey() {
+        // There is no production insert() path, so provoke the duplicate-key case with raw collection
+        // writes to prove the unique (projectId, personKey) index is actually in place.
+        var collection = mongoTemplate.getCollection(COLLECTION_NAME);
+        collection.insertOne(new Document(PendingSharingInvitation.PROJECT_ID, projectId.id())
+                                     .append(PendingSharingInvitation.PERSON_KEY, "new@x.org"));
+        try {
+            collection.insertOne(new Document(PendingSharingInvitation.PROJECT_ID, projectId.id())
+                                         .append(PendingSharingInvitation.PERSON_KEY, "new@x.org"));
+            fail("Expected a duplicate-key write error");
+        } catch (MongoWriteException e) {
+            assertThat(e.getError().getCategory(), is(ErrorCategory.DUPLICATE_KEY));
+        }
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitation_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/sharing/PendingSharingInvitation_TestCase.java
@@ -1,0 +1,95 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import edu.stanford.protege.webprotege.MockingUtils;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PendingSharingInvitation_TestCase {
+
+    private final ProjectId projectId = MockingUtils.mockProjectId();
+
+    private final UserId invitedBy = MockingUtils.mockUserId();
+
+    private final Instant createdAt = Instant.parse("2024-01-01T00:00:00Z");
+
+    private PendingSharingInvitation invitation(String personId, String personKey) {
+        return new PendingSharingInvitation(projectId, personId, personKey, SharingPermission.VIEW, invitedBy, createdAt);
+    }
+
+    @Test
+    public void shouldTrimTheAsTypedPersonId() {
+        assertThat(invitation("  new@x.org  ", "new@x.org").personId(), is("new@x.org"));
+    }
+
+    @Test
+    public void shouldNormalizeThePersonKey() {
+        assertThat(invitation("New@X.org", "  New@X.org  ").personKey(), is("new@x.org"));
+    }
+
+    @Test
+    public void shouldRejectABlankPersonKey() {
+        assertThrows(IllegalArgumentException.class, () -> invitation("   ", "   "));
+    }
+
+    @Test
+    public void shouldRejectANullPersonKey() {
+        assertThrows(NullPointerException.class, () -> invitation("x", null));
+    }
+
+    @Test
+    public void shouldRejectANullProjectId() {
+        assertThrows(NullPointerException.class,
+                     () -> new PendingSharingInvitation(null, "x", "x", SharingPermission.VIEW, invitedBy, createdAt));
+    }
+
+    @Test
+    public void shouldRejectANullPersonId() {
+        assertThrows(NullPointerException.class,
+                     () -> new PendingSharingInvitation(projectId, null, "x", SharingPermission.VIEW, invitedBy, createdAt));
+    }
+
+    @Test
+    public void shouldRejectANullSharingPermission() {
+        assertThrows(NullPointerException.class,
+                     () -> new PendingSharingInvitation(projectId, "x", "x", null, invitedBy, createdAt));
+    }
+
+    @Test
+    public void shouldRejectANullInvitedBy() {
+        assertThrows(NullPointerException.class,
+                     () -> new PendingSharingInvitation(projectId, "x", "x", SharingPermission.VIEW, null, createdAt));
+    }
+
+    @Test
+    public void shouldRejectANullCreatedAt() {
+        assertThrows(NullPointerException.class,
+                     () -> new PendingSharingInvitation(projectId, "x", "x", SharingPermission.VIEW, invitedBy, null));
+    }
+
+    @Test
+    public void normalizeKeyShouldTrimAndLowercase() {
+        assertThat(PendingSharingInvitation.normalizeKey("  New@X.org  "), is("new@x.org"));
+    }
+
+    @Test
+    public void normalizeKeyShouldMapNullToEmptyString() {
+        assertThat(PendingSharingInvitation.normalizeKey(null), is(""));
+    }
+
+    @Test
+    public void isEmailShapedShouldAgreeWithContainsAtOnNormalizedKeys() {
+        // Both the manager's email gate and the redeemer's match path delegate to this predicate, so
+        // pin its behaviour: email-shapedness is exactly "the normalized key contains an '@'".
+        assertThat(PendingSharingInvitation.isEmailShaped("new@x.org"), is(true));
+        assertThat(PendingSharingInvitation.isEmailShaped("jdoe"), is(false));
+        assertThat(PendingSharingInvitation.isEmailShaped(""), is(false));
+        assertThat(PendingSharingInvitation.isEmailShaped(null), is(false));
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/sharing/ProjectSharingSettingsManagerImpl_TestCase.java
@@ -12,12 +12,15 @@ import edu.stanford.protege.webprotege.user.UserLookupException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -28,10 +31,14 @@ import static edu.stanford.protege.webprotege.access.BuiltInRole.CAN_VIEW;
 import static edu.stanford.protege.webprotege.authorization.Subject.forAnySignedInUser;
 import static edu.stanford.protege.webprotege.authorization.Subject.forUser;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -62,6 +69,12 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
     @Mock
     private UserDetailsManager userLookup;
 
+    @Mock
+    private PendingSharingInvitationRepository pendingInvitationRepository;
+
+    @Mock
+    private SharingInvitationEmailer invitationEmailer;
+
     private ProjectSharingSettingsManagerImpl manager;
 
     private final ProjectId projectId = MockingUtils.mockProjectId();
@@ -78,7 +91,10 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
 
     @BeforeEach
     public void setUp() {
-        manager = new ProjectSharingSettingsManagerImpl(accessManager, userLookup);
+        manager = new ProjectSharingSettingsManagerImpl(accessManager,
+                                                        userLookup,
+                                                        pendingInvitationRepository,
+                                                        invitationEmailer);
     }
 
     /**
@@ -538,5 +554,301 @@ public class ProjectSharingSettingsManagerImpl_TestCase {
         assertThat(thrown, is(accessManagerFailure));
         assertThat(thrown.getSuppressed().length, is(1));
         assertThat(thrown.getSuppressed()[0], is(lookupException));
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Pending invitations for confirmed-absent people (GH #177).
+    // ----------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldUpsertInvitationAndEmailWhenUnknownEmailIsShared() {
+        PersonId emailPerson = PersonId.get("new@x.org");
+        when(userLookup.getUserByUserIdOrEmail("new@x.org")).thenReturn(Optional.empty());
+        when(pendingInvitationRepository.upsert(any())).thenReturn(true);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(emailPerson, SharingPermission.EDIT)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        ArgumentCaptor<PendingSharingInvitation> captor = ArgumentCaptor.forClass(PendingSharingInvitation.class);
+        verify(pendingInvitationRepository).upsert(captor.capture());
+        PendingSharingInvitation invitation = captor.getValue();
+        assertThat(invitation.projectId(), is(projectId));
+        assertThat(invitation.personId(), is("new@x.org"));
+        assertThat(invitation.personKey(), is("new@x.org"));
+        assertThat(invitation.sharingPermission(), is(SharingPermission.EDIT));
+        assertThat(invitation.invitedBy(), is(actingUserId));
+
+        verify(invitationEmailer).sendInvitationEmail(projectId, "new@x.org", actingUserId);
+    }
+
+    @Test
+    public void shouldStoreInvitationButNotEmailWhenUnknownUsernameIsShared() {
+        PersonId usernamePerson = PersonId.get("jdoe");
+        when(userLookup.getUserByUserIdOrEmail("jdoe")).thenReturn(Optional.empty());
+        when(pendingInvitationRepository.upsert(any())).thenReturn(true);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(usernamePerson, SharingPermission.VIEW)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        verify(pendingInvitationRepository).upsert(any());
+        // The typed id does not look like an email address, so no invitation email is sent.
+        verify(invitationEmailer, never()).sendInvitationEmail(any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotEmailAgainWhenReSavingAnAlreadyStoredInvitation() {
+        PersonId emailPerson = PersonId.get("new@x.org");
+        when(userLookup.getUserByUserIdOrEmail("new@x.org")).thenReturn(Optional.empty());
+        // The upsert reports that it replaced an existing invitation rather than inserting a new one.
+        when(pendingInvitationRepository.upsert(any())).thenReturn(false);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(emailPerson, SharingPermission.EDIT)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        verify(pendingInvitationRepository).upsert(any());
+        verify(invitationEmailer, never()).sendInvitationEmail(any(), any(), any());
+    }
+
+    @Test
+    public void shouldReconcileKeepingOnlyConfirmedAbsentKeys() {
+        PersonId emailPerson = PersonId.get("new@x.org");
+        when(userLookup.getUserByUserIdOrEmail("new@x.org")).thenReturn(Optional.empty());
+        when(pendingInvitationRepository.upsert(any())).thenReturn(true);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(emailPerson, SharingPermission.EDIT)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> keysCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(pendingInvitationRepository).deleteByProjectIdWherePersonKeyNotIn(eq(projectId), keysCaptor.capture());
+        assertThat(keysCaptor.getValue(), contains("new@x.org"));
+    }
+
+    @Test
+    public void shouldReconcileAwayAllPendingInvitationsWhenNoneAreSubmitted() {
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of());
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> keysCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(pendingInvitationRepository).deleteByProjectIdWherePersonKeyNotIn(eq(projectId), keysCaptor.capture());
+        assertThat(keysCaptor.getValue(), is(empty()));
+    }
+
+    @Test
+    public void shouldNotUpsertButShouldKeepFailedKeyWhenLookupThrows() {
+        PersonId failing = PersonId.get("Failing@x.org");
+        UserLookupException lookupException = new UserLookupException("boom", new RuntimeException("cause"));
+        when(userLookup.getUserByUserIdOrEmail("Failing@x.org")).thenThrow(lookupException);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(failing, SharingPermission.EDIT)));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(lookupException));
+
+        // A lookup that threw must not create/update an invitation for that entry.
+        verify(pendingInvitationRepository, never()).upsert(any());
+        // But its key is preserved on reconciliation so any existing pending row for it is not wiped.
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> keysCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(pendingInvitationRepository).deleteByProjectIdWherePersonKeyNotIn(eq(projectId), keysCaptor.capture());
+        assertThat(keysCaptor.getValue(), contains("failing@x.org"));
+    }
+
+    @Test
+    public void shouldLeavePendingStoreUntouchedWhenAPhaseFailsAndStillEmailOnceWhenTheSaveIsRetried() {
+        PersonId emailPerson = PersonId.get("new@x.org");
+        when(userLookup.getUserByUserIdOrEmail("new@x.org")).thenReturn(Optional.empty());
+        UserId resolvedUserId = MockingUtils.mockUserId();
+        PersonId resolvedPersonId = PersonId.of(resolvedUserId);
+        when(userLookup.getUserByUserIdOrEmail(resolvedPersonId.getId())).thenReturn(Optional.of(resolvedUserId));
+
+        RuntimeException phaseFailure = new RuntimeException("access manager RPC failure");
+        doThrow(phaseFailure).doNothing().when(accessManager)
+                             .setAssignedRoles(eq(forUser(resolvedUserId)), eq(projectResource), any());
+        when(pendingInvitationRepository.upsert(any())).thenReturn(true);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(emailPerson, SharingPermission.VIEW),
+                        new SharingSetting(resolvedPersonId, SharingPermission.EDIT)));
+
+        // First attempt: a phase throws, so the pending store must be left completely untouched -
+        // otherwise the one-shot fresh-insert email signal would be consumed for a save that failed.
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.setProjectSharingSettings(actingUserId, settings));
+        assertThat(thrown, is(phaseFailure));
+        verify(pendingInvitationRepository, never()).upsert(any());
+        verify(pendingInvitationRepository, never()).deleteByProjectIdWherePersonKeyNotIn(any(), anyCollection());
+        verify(invitationEmailer, never()).sendInvitationEmail(any(), any(), any());
+
+        // Retry: the phases now succeed, the invitation is stored, and it is emailed exactly once.
+        manager.setProjectSharingSettings(actingUserId, settings);
+        verify(pendingInvitationRepository, times(1)).upsert(any());
+        verify(invitationEmailer, times(1)).sendInvitationEmail(projectId, "new@x.org", actingUserId);
+    }
+
+    @Test
+    public void shouldDeduplicateConfirmedAbsentEntriesByNormalizedKeyWithFirstSubmittedWinning() {
+        PersonId mixedCase = PersonId.get("New@X.org");
+        PersonId lowerCase = PersonId.get("new@x.org");
+        when(userLookup.getUserByUserIdOrEmail("New@X.org")).thenReturn(Optional.empty());
+        when(userLookup.getUserByUserIdOrEmail("new@x.org")).thenReturn(Optional.empty());
+        when(pendingInvitationRepository.upsert(any())).thenReturn(true);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(mixedCase, SharingPermission.EDIT),
+                        new SharingSetting(lowerCase, SharingPermission.VIEW)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        // Both entries normalize to the same key - only the first submitted one is stored/emailed
+        // (deterministically, following the submitted list order).
+        ArgumentCaptor<PendingSharingInvitation> captor = ArgumentCaptor.forClass(PendingSharingInvitation.class);
+        verify(pendingInvitationRepository, times(1)).upsert(captor.capture());
+        assertThat(captor.getValue().personId(), is("New@X.org"));
+        assertThat(captor.getValue().sharingPermission(), is(SharingPermission.EDIT));
+        verify(invitationEmailer, times(1)).sendInvitationEmail(projectId, "New@X.org", actingUserId);
+    }
+
+    @Test
+    public void shouldReconcileAwayInvitationForPersonWhoNowResolvesToARealUser() {
+        UserId resolvedUserId = MockingUtils.mockUserId();
+        PersonId nowResolvingPerson = PersonId.get("was-pending@x.org");
+        when(userLookup.getUserByUserIdOrEmail("was-pending@x.org")).thenReturn(Optional.of(resolvedUserId));
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(nowResolvingPerson, SharingPermission.EDIT)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        // They now resolve to a real user, so no invitation is stored for them ...
+        verify(pendingInvitationRepository, never()).upsert(any());
+        // ... and reconciliation drops any existing pending row for them (their key is not kept).
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> keysCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(pendingInvitationRepository).deleteByProjectIdWherePersonKeyNotIn(eq(projectId), keysCaptor.capture());
+        assertThat(keysCaptor.getValue(), is(empty()));
+    }
+
+    @Test
+    public void shouldStillReconcileAndKeepUpsertingWhenOneUpsertThrows() {
+        PersonId first = PersonId.get("first@x.org");
+        PersonId second = PersonId.get("second@x.org");
+        when(userLookup.getUserByUserIdOrEmail("first@x.org")).thenReturn(Optional.empty());
+        when(userLookup.getUserByUserIdOrEmail("second@x.org")).thenReturn(Optional.empty());
+        // The first upsert fails; the second must still be attempted, and the save must not fail.
+        when(pendingInvitationRepository.upsert(any()))
+                .thenThrow(new RuntimeException("store failure")).thenReturn(true);
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(first, SharingPermission.EDIT),
+                        new SharingSetting(second, SharingPermission.VIEW)));
+
+        assertDoesNotThrow(() -> manager.setProjectSharingSettings(actingUserId, settings));
+
+        // Both upserts attempted despite the first failing, and reconciliation still ran.
+        verify(pendingInvitationRepository, times(2)).upsert(any());
+        verify(pendingInvitationRepository).deleteByProjectIdWherePersonKeyNotIn(eq(projectId), anyCollection());
+    }
+
+    @Test
+    public void shouldSkipConfirmedAbsentEntryWhoseNormalizedKeyIsEmpty() {
+        PersonId blank = PersonId.get("   ");
+        when(userLookup.getUserByUserIdOrEmail(any())).thenReturn(Optional.empty());
+
+        ProjectSharingSettings settings = new ProjectSharingSettings(
+                projectId,
+                Optional.empty(),
+                List.of(new SharingSetting(blank, SharingPermission.EDIT)));
+
+        manager.setProjectSharingSettings(actingUserId, settings);
+
+        // A blank/whitespace id normalizes to an empty key and cannot be a valid invitation.
+        verify(pendingInvitationRepository, never()).upsert(any());
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // getProjectSharingSettings merge + read-failure propagation (GH #177).
+    // ----------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldMergePendingInvitationsIntoSharingSettingsWithActiveWinningOnKeyCollision() {
+        UserId activeUserId = MockingUtils.mockUserId();
+        givenCurrentAccess(activeUserId, CAN_VIEW.getRoleId());
+        when(userLookup.getEmail(activeUserId)).thenReturn(Optional.empty());
+
+        PendingSharingInvitation collidingWithActive = new PendingSharingInvitation(
+                projectId, activeUserId.id(), activeUserId.id(), SharingPermission.MANAGE, actingUserId, Instant.now());
+        PendingSharingInvitation distinctPending = new PendingSharingInvitation(
+                projectId, "pending@x.org", "pending@x.org", SharingPermission.EDIT, actingUserId, Instant.now());
+        when(pendingInvitationRepository.findByProjectId(projectId))
+                .thenReturn(List.of(collidingWithActive, distinctPending));
+
+        ProjectSharingSettings result = manager.getProjectSharingSettings(projectId);
+
+        // The active collaborator wins on the key collision (their VIEW, not the pending MANAGE), and
+        // the distinct pending invitation is surfaced with its stored permission.
+        assertThat(result.getSharingSettings(), containsInAnyOrder(
+                new SharingSetting(PersonId.of(activeUserId), SharingPermission.VIEW),
+                new SharingSetting(PersonId.get("pending@x.org"), SharingPermission.EDIT)));
+    }
+
+    @Test
+    public void shouldSuppressPendingInvitationMatchingAnActiveCollaboratorsKnownEmail() {
+        UserId activeUserId = MockingUtils.mockUserId();
+        givenCurrentAccess(activeUserId, CAN_VIEW.getRoleId());
+        when(userLookup.getEmail(activeUserId)).thenReturn(Optional.of("Active@x.org"));
+
+        PendingSharingInvitation matchingEmail = new PendingSharingInvitation(
+                projectId, "active@x.org", "active@x.org", SharingPermission.MANAGE, actingUserId, Instant.now());
+        when(pendingInvitationRepository.findByProjectId(projectId)).thenReturn(List.of(matchingEmail));
+
+        ProjectSharingSettings result = manager.getProjectSharingSettings(projectId);
+
+        // The pending invitation targets the active collaborator's own (known) email, so it is hidden.
+        assertThat(result.getSharingSettings(), contains(
+                new SharingSetting(PersonId.of(activeUserId), SharingPermission.VIEW)));
+    }
+
+    @Test
+    public void shouldPropagatePendingStoreReadFailureFromGetProjectSharingSettings() {
+        RuntimeException readFailure = new RuntimeException("pending store unavailable");
+        when(pendingInvitationRepository.findByProjectId(projectId)).thenThrow(readFailure);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                                () -> manager.getProjectSharingSettings(projectId));
+        assertThat(thrown, is(readFailure));
     }
 }

--- a/src/test/java/edu/stanford/protege/webprotege/sharing/SharingInvitationEmailer_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/sharing/SharingInvitationEmailer_TestCase.java
@@ -1,0 +1,170 @@
+package edu.stanford.protege.webprotege.sharing;
+
+import edu.stanford.protege.webprotege.MockingUtils;
+import edu.stanford.protege.webprotege.app.PlaceUrl;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import edu.stanford.protege.webprotege.filemanager.FileContents;
+import edu.stanford.protege.webprotege.mail.MessageHeader;
+import edu.stanford.protege.webprotege.mail.SendMail;
+import edu.stanford.protege.webprotege.project.ProjectDetails;
+import edu.stanford.protege.webprotege.project.ProjectDetailsRepository;
+import edu.stanford.protege.webprotege.templates.TemplateEngine;
+import edu.stanford.protege.webprotege.user.UserDetails;
+import edu.stanford.protege.webprotege.user.UserDetailsManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link SharingInvitationEmailer}.  Emails are sent asynchronously, so successful-send
+ * assertions use Mockito {@code timeout(...)} and skip assertions use {@code after(...).never()}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SharingInvitationEmailer_TestCase {
+
+    @Mock
+    private ProjectDetailsRepository projectDetailsRepository;
+
+    @Mock
+    private UserDetailsManager userDetailsManager;
+
+    @Mock
+    private FileContents templateFile;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private PlaceUrl placeUrl;
+
+    @Mock
+    private SendMail sendMail;
+
+    private SharingInvitationEmailer emailer;
+
+    private final ProjectId projectId = MockingUtils.mockProjectId();
+
+    private final UserId invitedBy = UserId.valueOf("owner");
+
+    @BeforeEach
+    public void setUp() {
+        emailer = new SharingInvitationEmailer(projectDetailsRepository,
+                                               userDetailsManager,
+                                               templateFile,
+                                               templateEngine,
+                                               placeUrl,
+                                               sendMail);
+        when(projectDetailsRepository.findOne(any())).thenReturn(Optional.empty());
+        when(placeUrl.getApplicationUrl()).thenReturn("http://webprotege.test");
+        when(templateFile.exists()).thenReturn(true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        emailer.shutdown();
+    }
+
+    @Test
+    public void shouldSendEmailWithTrimmedRecipientAndRenderedBody() {
+        when(templateFile.getContents()).thenReturn("template body");
+        when(userDetailsManager.getUserDetails(invitedBy)).thenReturn(Optional.empty());
+        when(templateEngine.populateTemplate(anyString(), any())).thenReturn("rendered body");
+
+        emailer.sendInvitationEmail(projectId, "  new@x.org  ", invitedBy);
+
+        verify(sendMail, timeout(2000)).sendMail(eq(List.of("new@x.org")), anyString(), eq("rendered body"),
+                                                 new MessageHeader[0]);
+
+        // The template is populated with the inviter (falling back to the raw id here), the project
+        // display name and the application url.
+        ArgumentCaptor<Map<String, Object>> objectsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(templateEngine).populateTemplate(eq("template body"), objectsCaptor.capture());
+        Map<String, Object> objects = objectsCaptor.getValue();
+        assertThat(objects.get("inviter"), is("owner"));
+        assertThat(objects.get("application.url"), is("http://webprotege.test"));
+        assertThat(objects.get("project.displayName"), is("a project"));
+    }
+
+    @Test
+    public void shouldRenderTheInviterDisplayNameWhenAvailable() {
+        when(templateFile.getContents()).thenReturn("template body");
+        when(userDetailsManager.getUserDetails(invitedBy))
+                .thenReturn(Optional.of(UserDetails.getUserDetails(invitedBy, "The Owner", Optional.empty())));
+        when(templateEngine.populateTemplate(anyString(), any())).thenReturn("rendered body");
+
+        emailer.sendInvitationEmail(projectId, "new@x.org", invitedBy);
+
+        ArgumentCaptor<Map<String, Object>> objectsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(templateEngine, timeout(2000)).populateTemplate(anyString(), objectsCaptor.capture());
+        assertThat(objectsCaptor.getValue().get("inviter"), is("The Owner"));
+    }
+
+    @Test
+    public void shouldNotSendWhenTemplateBodyIsBlank() {
+        when(templateFile.getContents()).thenReturn("   ");
+
+        emailer.sendInvitationEmail(projectId, "new@x.org", invitedBy);
+
+        verify(sendMail, after(500).never()).sendMail(any(), anyString(), anyString(), any(MessageHeader[].class));
+    }
+
+    @Test
+    public void shouldNotSendWhenTemplateFileDoesNotExist() {
+        // Structural guard: an absent template file skips the send (no coupling to error-text wording).
+        when(templateFile.exists()).thenReturn(false);
+
+        emailer.sendInvitationEmail(projectId, "new@x.org", invitedBy);
+
+        verify(sendMail, after(500).never()).sendMail(any(), anyString(), anyString(), any(MessageHeader[].class));
+    }
+
+    @Test
+    public void shouldStripControlCharactersFromTheSubjectAndInviter() {
+        ProjectDetails projectDetails = mock(ProjectDetails.class);
+        when(projectDetails.getDisplayName()).thenReturn("Evil\r\nProject");
+        when(projectDetailsRepository.findOne(any())).thenReturn(Optional.of(projectDetails));
+        when(userDetailsManager.getUserDetails(invitedBy))
+                .thenReturn(Optional.of(UserDetails.getUserDetails(invitedBy, "Bad\r\nOwner", Optional.empty())));
+        when(templateFile.getContents()).thenReturn("template body");
+        when(templateEngine.populateTemplate(anyString(), any())).thenReturn("rendered body");
+
+        emailer.sendInvitationEmail(projectId, "new@x.org", invitedBy);
+
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sendMail, timeout(2000)).sendMail(any(), subjectCaptor.capture(), anyString(),
+                                                 any(MessageHeader[].class));
+        String subject = subjectCaptor.getValue();
+        assertThat(subject.contains("\r"), is(false));
+        assertThat(subject.contains("\n"), is(false));
+        assertThat(subject.contains("EvilProject"), is(true));
+
+        // The inviter that flows into the template body is sanitized too.
+        ArgumentCaptor<Map<String, Object>> objectsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(templateEngine).populateTemplate(anyString(), objectsCaptor.capture());
+        assertThat(objectsCaptor.getValue().get("inviter"), is("BadOwner"));
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/user/GetAuthenticatedUserDetailsActionHandler_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/user/GetAuthenticatedUserDetailsActionHandler_TestCase.java
@@ -1,0 +1,93 @@
+package edu.stanford.protege.webprotege.user;
+
+import edu.stanford.protege.webprotege.access.AccessManager;
+import edu.stanford.protege.webprotege.authorization.Capability;
+import edu.stanford.protege.webprotege.common.UserId;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import edu.stanford.protege.webprotege.sharing.PendingSharingInvitationRedeemer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the sharing-invitation redemption hook added to
+ * {@link GetAuthenticatedUserDetailsActionHandler}: redemption runs before the capability closure is
+ * computed, is skipped for guests, and never breaks login when it fails.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GetAuthenticatedUserDetailsActionHandler_TestCase {
+
+    @Mock
+    private AccessManager accessManager;
+
+    @Mock
+    private UserDetailsManager userDetailsManager;
+
+    @Mock
+    private PendingSharingInvitationRedeemer invitationRedeemer;
+
+    private GetAuthenticatedUserDetailsActionHandler handler;
+
+    private final UserId userId = UserId.valueOf("jdoe");
+
+    @BeforeEach
+    public void setUp() {
+        handler = new GetAuthenticatedUserDetailsActionHandler(accessManager, userDetailsManager, invitationRedeemer);
+        when(userDetailsManager.getUserDetails(any())).thenReturn(Optional.empty());
+        when(accessManager.getCapabilityClosure(any(), any(), any())).thenReturn(Collections.<Capability>emptySet());
+    }
+
+    @Test
+    public void shouldRedeemInvitationsBeforeComputingCapabilityClosure() {
+        ExecutionContext executionContext = new ExecutionContext(userId, "jwt-token", "corr-id");
+
+        handler.execute(new GetAuthenticatedUserDetailsRequest(), executionContext);
+
+        InOrder inOrder = inOrder(invitationRedeemer, accessManager);
+        inOrder.verify(invitationRedeemer).redeem(userId, "jwt-token");
+        inOrder.verify(accessManager).getCapabilityClosure(any(), any(), any());
+    }
+
+    @Test
+    public void shouldSkipRedemptionForTheGuestUser() {
+        ExecutionContext executionContext = new ExecutionContext(UserId.getGuest(), "jwt-token", "corr-id");
+
+        var response = handler.execute(new GetAuthenticatedUserDetailsRequest(), executionContext);
+
+        verify(invitationRedeemer, never()).redeem(any(), any());
+        assertThat(response.userDetails(), is(UserDetails.getGuestUserDetails()));
+    }
+
+    @Test
+    public void shouldStillReturnDetailsWhenRedemptionFails() {
+        doThrow(new RuntimeException("redeemer blew up")).when(invitationRedeemer).redeem(any(), any());
+        ExecutionContext executionContext = new ExecutionContext(userId, "jwt-token", "corr-id");
+
+        var response = assertDoesNotThrow(
+                () -> handler.execute(new GetAuthenticatedUserDetailsRequest(), executionContext));
+
+        assertThat(response, is(notNullValue()));
+        // Login proceeds: the capability closure is still computed and returned.
+        verify(accessManager).getCapabilityClosure(any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Problem

Sharing a project with someone who has never logged into WebProtégé silently does nothing. The unresolved entry is skipped with only a log warning, it disappears from the sharing page on the next load, and neither the owner nor the invited person is told anything. This is the long-standing `TODO` in `ProjectSharingSettingsManagerImpl.setProjectSharingSettings`.

## What this PR does

When a submitted sharing entry cannot be resolved to a registered user, the entry is now stored as a **pending invitation** instead of being dropped:

- **The row stays visible.** Pending invitations are merged back into the sharing settings, so the entry no longer vanishes from the sharing page. Removing the row and saving deletes the invitation.
- **The invitee gets an email.** When the typed identifier looks like an email address, an invitation email is sent (once, on first creation) using the existing mail infrastructure and a new Mustache template.
- **Access is granted on first login.** The first time that person arrives as an authenticated user, the stored permission is granted automatically and the invitation is consumed. This hooks into `GetAuthenticatedUserDetailsActionHandler`, before the capability closure is computed, so the shared project is visible immediately.

## Safety properties

- An email-keyed invitation is redeemed **only** when the login token carries a matching email claim with `email_verified=true` — never through the username path. This matters because the deployed realm allows self-registration without email verification and uses the email address as the username, so without this check anyone could register an invited address and take over the invitation.
- Infrastructure failures during user lookup never create or delete invitations (a failed lookup could mask an existing user), keeping the behavior introduced for #179 intact.
- All invitation storage, reconciliation, and email dispatch happen only after the role-update phases succeed, so a failed save leaves the invitation store untouched and a retried save still sends the email exactly once.
- Redemption can never break login: every failure path is caught and logged.
- A consumed or revoked invitation is never re-created by a failed grant, so removed access cannot resurrect.

## Storage

New MongoDB collection `PendingSharingInvitations` with a unique `(projectId, personKey)` index, following the existing repository patterns.

## Tests

77 new or extended tests across five classes, including a Testcontainers integration test against real MongoDB. Full suite: 1,894 tests passing.

## Follow-ups (tracked separately)

- Set `verifyEmail=true` in the webprotege-keycloak realm so email invitations activate end to end.
- Filter unverified accounts out of user lookups in webprotege-user-management-service.
- A "pending" indicator in the sharing UI (needs changes in webprotege-backend-api and webprotege-gwt-ui).