### PR TITLE
Send the field names the user-management service binds to (fixes #183)

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManagerImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/UserDetailsManagerImpl.java
@@ -34,7 +34,7 @@ public class UserDetailsManagerImpl implements UserDetailsManager {
     @Override
     public List<UserId> getUserIdsContainingIgnoreCase(String userName, int limit) {
         try {
-            return getUsersExecutor.execute(new UsersQueryRequest(userName), new ExecutionContext()).get().completions();
+            return getUsersExecutor.execute(new UsersQueryRequest(userName, false), new ExecutionContext()).get().completions();
         } catch (Exception e) {
             logger.error("Error calling get users",e);
             return new ArrayList<>();
@@ -113,7 +113,7 @@ public class UserDetailsManagerImpl implements UserDetailsManager {
     public Optional<UserId> getUserByUserIdOrEmail(String userNameOrEmail) {
         List<UserId> response;
         try {
-            response = getUsersExecutor.execute(new UsersQueryRequest(userNameOrEmail), new ExecutionContext())
+            response = getUsersExecutor.execute(new UsersQueryRequest(userNameOrEmail, true), new ExecutionContext())
                                         .get(3, TimeUnit.SECONDS)
                                         .completions();
         } catch (InterruptedException e) {

--- a/src/main/java/edu/stanford/protege/webprotege/user/UsersQueryRequest.java
+++ b/src/main/java/edu/stanford/protege/webprotege/user/UsersQueryRequest.java
@@ -1,8 +1,17 @@
 package edu.stanford.protege.webprotege.user;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.stanford.protege.webprotege.common.Request;
 
-public record UsersQueryRequest(String userName) implements Request<UsersQueryResponse> {
+/**
+ * Mirrors the request contract owned by the user-management service on this channel: the
+ * search term is serialized as {@code completionText} and {@code exactMatch} selects between
+ * exact resolution and completion-style substring search.  The service binds strictly by
+ * these JSON names - a differently-named term field arrives as {@code null}, which the
+ * service treats as an unfiltered query that returns every user in the realm.
+ */
+public record UsersQueryRequest(@JsonProperty("completionText") String completionText,
+                                @JsonProperty("exactMatch") boolean exactMatch) implements Request<UsersQueryResponse> {
 
     public final static String CHANNEL = "webprotege.usersquery.QueryUsers";
 

--- a/src/test/java/edu/stanford/protege/webprotege/metaproject/UserDetailsManagerImpl_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/metaproject/UserDetailsManagerImpl_TestCase.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -133,5 +134,35 @@ public void shouldThrowNullPointerExceptionIf_Repository_IsNull() {
 
         assertThrows(UserLookupException.class,
                       () -> userDetailsManagerImpl.getUserByUserIdOrEmail(userId.id()));
+    }
+
+    @Test
+    public void shouldSendAnExactMatchQueryCarryingTheTermWhenResolvingAUser() throws Exception {
+        UsersQueryResponse response = new UsersQueryResponse(List.of(userId));
+        CompletableFuture<UsersQueryResponse> future = mock(CompletableFuture.class);
+        when(future.get(3, TimeUnit.SECONDS)).thenReturn(response);
+        when(getUsersExecutor.execute(any(), any())).thenReturn(future);
+
+        userDetailsManagerImpl.getUserByUserIdOrEmail(userId.id());
+
+        var requestCaptor = org.mockito.ArgumentCaptor.forClass(UsersQueryRequest.class);
+        verify(getUsersExecutor).execute(requestCaptor.capture(), any());
+        assertThat(requestCaptor.getValue().completionText(), is(userId.id()));
+        assertThat(requestCaptor.getValue().exactMatch(), is(true));
+    }
+
+    @Test
+    public void shouldSendASubstringQueryWhenSearchingForCompletions() throws Exception {
+        UsersQueryResponse response = new UsersQueryResponse(List.of(userId));
+        CompletableFuture<UsersQueryResponse> future = mock(CompletableFuture.class);
+        when(future.get()).thenReturn(response);
+        when(getUsersExecutor.execute(any(), any())).thenReturn(future);
+
+        userDetailsManagerImpl.getUserIdsContainingIgnoreCase("abc", 10);
+
+        var requestCaptor = org.mockito.ArgumentCaptor.forClass(UsersQueryRequest.class);
+        verify(getUsersExecutor).execute(requestCaptor.capture(), any());
+        assertThat(requestCaptor.getValue().completionText(), is("abc"));
+        assertThat(requestCaptor.getValue().exactMatch(), is(false));
     }
 }

--- a/src/test/java/edu/stanford/protege/webprotege/user/UsersQueryRequest_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/user/UsersQueryRequest_TestCase.java
@@ -1,0 +1,26 @@
+package edu.stanford.protege.webprotege.user;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class UsersQueryRequest_TestCase {
+
+    @Test
+    public void shouldSerializeWithTheJsonFieldNamesTheUserManagementServiceBindsTo() throws Exception {
+        var json = new ObjectMapper().readTree(
+                new ObjectMapper().writeValueAsString(new UsersQueryRequest("jdoe@x.org", true)));
+        assertThat(json.get("completionText").asText(), is("jdoe@x.org"));
+        assertThat(json.get("exactMatch").asBoolean(), is(true));
+    }
+
+    @Test
+    public void shouldDeserializeFromTheWireFieldNames() throws Exception {
+        var request = new ObjectMapper().readValue(
+                "{\"completionText\":\"jdoe@x.org\",\"exactMatch\":false}", UsersQueryRequest.class);
+        assertThat(request.completionText(), is("jdoe@x.org"));
+        assertThat(request.exactMatch(), is(false));
+    }
+}


### PR DESCRIPTION
## Problem

The backend's `UsersQueryRequest` serialized the search term as `userName`, but the user-management service — the owner of the `webprotege.usersquery.QueryUsers` channel — binds the term to `completionText` and also reads an `exactMatch` flag. The term therefore arrived as `null`, and the service queried Keycloak with no username filter, returning **every user in the realm** for every lookup. Verified against a live deployment by probing the channel directly over RabbitMQ and confirming `GET /admin/realms/webprotege/users?exact=false` (no username parameter) in the nginx access log.

## Impact

- Since #179, the multi-user response trips the ambiguity guard, so **saving sharing settings fails with a 500** for any entry — including existing collaborators.
- Before #179, the same failure was silently swallowed into "user does not exist", so entries were skipped without a trace — a plausible root condition behind the original silent-sharing reports (#177, protegeproject/webprotege-backend-api#65).
- User-id autocomplete had the same mismatch and only appeared to work because it returned all users regardless of input.

## Fix

- `UsersQueryRequest` now carries `completionText` and `exactMatch`, with explicit `@JsonProperty` names pinning the wire contract.
- `getUserByUserIdOrEmail` sends `exactMatch=true` (exact resolution); `getUserIdsContainingIgnoreCase` sends `exactMatch=false` (completion search).
- Tests pin both the request contents per call site (argument capture) and the JSON field names (round-trip serialization), so a future rename on either side fails a test instead of silently returning all users.

Full suite: 1,838 tests passing.