### PR TITLE
Make stored application preferences readable and templates renderable (fixes #185, fixes #186)

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ApplicationBeansConfiguration.java
@@ -142,11 +142,6 @@ public class ApplicationBeansConfiguration {
     }
 
     @Bean
-    public DefaultMustacheFactory providesMustacheFactory() {
-        return new DefaultMustacheFactory();
-    }
-
-    @Bean
     DataDirectoryProvider getDataDirectoryProvider() {
         return new DataDirectoryProvider();
     }

--- a/src/main/java/edu/stanford/protege/webprotege/app/ApplicationPreferences.java
+++ b/src/main/java/edu/stanford/protege/webprotege/app/ApplicationPreferences.java
@@ -23,8 +23,11 @@ public class ApplicationPreferences {
 
     public static final String ID = "Preferences";
 
+    // Not final: Spring Data populates this field reflectively when reading the document
+    // back, and it refuses to write to a final field - a final id makes every read of a
+    // stored document fail with "Cannot set property id".
     @SuppressWarnings("unused")
-    private final String id = ID;
+    private String id = ID;
 
     private final String applicationName;
 

--- a/src/main/java/edu/stanford/protege/webprotege/app/ApplicationPreferencesStore.java
+++ b/src/main/java/edu/stanford/protege/webprotege/app/ApplicationPreferencesStore.java
@@ -58,8 +58,10 @@ public class ApplicationPreferencesStore implements Repository {
             var applicationPreferences = mongoTemplate.findOne(new Query(), ApplicationPreferences.class);
             if (applicationPreferences == null) {
                 var newApplicationPreferences = DefaultApplicationPreferences.get();
-                mongoTemplate.upsert(queryById(),
-                                     new Update(), ApplicationPreferences.class);
+                // Persist the complete defaults document.  An empty upsert here would plant a
+                // bare {_id: "Preferences"} skeleton that is unreadable once the in-memory
+                // cache is gone, poisoning every read after the next restart.
+                mongoTemplate.save(newApplicationPreferences);
                 cachedPreferences = newApplicationPreferences;
             }
             else {

--- a/src/test/java/edu/stanford/protege/webprotege/app/ApplicationPreferencesStore_IT.java
+++ b/src/test/java/edu/stanford/protege/webprotege/app/ApplicationPreferencesStore_IT.java
@@ -1,0 +1,60 @@
+package edu.stanford.protege.webprotege.app;
+
+import edu.stanford.protege.webprotege.MongoTestExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.annotation.DirtiesContext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@SpringBootTest(properties = {"webprotege.rabbitmq.commands-subscribe=false"})
+@ExtendWith({MongoTestExtension.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ApplicationPreferencesStore_IT {
+
+    public static final String COLLECTION_NAME = "ApplicationPreferences";
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @AfterEach
+    public void tearDown() {
+        mongoTemplate.getCollection(COLLECTION_NAME).drop();
+    }
+
+    @Test
+    public void shouldPersistCompleteDefaultsOnAReadMissSoALaterReadSucceeds() {
+        var firstStore = new ApplicationPreferencesStore(mongoTemplate);
+        var defaults = firstStore.getApplicationPreferences();
+
+        // A fresh store has no in-memory cache, so this read must come from the stored
+        // document - previously the miss above planted a bare {_id: "Preferences"}
+        // skeleton and this read failed to instantiate the preferences.
+        var freshStore = new ApplicationPreferencesStore(mongoTemplate);
+        assertThat(freshStore.getApplicationPreferences(), is(defaults));
+    }
+
+    @Test
+    public void shouldReadBackExplicitlySavedPreferences() {
+        var savedPreferences = new ApplicationPreferences("The app name",
+                                                          "notify@example.org",
+                                                          new ApplicationLocation("https", "example.org", "", 443),
+                                                          42L);
+        var firstStore = new ApplicationPreferencesStore(mongoTemplate);
+        firstStore.setApplicationPreferences(savedPreferences);
+
+        assertThat(mongoTemplate.findOne(new Query(), ApplicationPreferences.class), is(notNullValue()));
+
+        // Previously any read of a stored document failed with "Cannot set property id"
+        // because the id field was final and outside the persistence constructor.
+        var freshStore = new ApplicationPreferencesStore(mongoTemplate);
+        assertThat(freshStore.getApplicationPreferences(), is(savedPreferences));
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/templates/TemplateEngine_IT.java
+++ b/src/test/java/edu/stanford/protege/webprotege/templates/TemplateEngine_IT.java
@@ -1,0 +1,31 @@
+package edu.stanford.protege.webprotege.templates;
+
+import edu.stanford.protege.webprotege.MongoTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@SpringBootTest(properties = {"webprotege.rabbitmq.commands-subscribe=false"})
+@ExtendWith({MongoTestExtension.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class TemplateEngine_IT {
+
+    @Autowired
+    private TemplateEngine templateEngine;
+
+    @Test
+    public void shouldRenderATemplateThroughTheApplicationContext() {
+        // TemplateEngine resolves its MustacheFactory through a lazy Provider, so a
+        // duplicate factory bean does not fail context startup - it only surfaces on the
+        // first real render.  This pins that the provider resolves to exactly one bean.
+        var body = templateEngine.populateTemplate("Hello {{name}}", Map.of("name", "WebProtege"));
+        assertThat(body, is("Hello WebProtege"));
+    }
+}


### PR DESCRIPTION
## Problem

Two dormant defects meant every templated backend email — comment notifications, watch notifications, and the new sharing invitations (#177) — failed at send time, while the application itself started cleanly:

1. **Stored `ApplicationPreferences` could never be read back** (#185). The `id` field was `final` and outside the persistence constructor, so Spring Data threw `Cannot set property id` on any read of an existing document. On top of that, the store's read-miss path upserted an *empty* update, planting a bare `{_id: "Preferences"}` skeleton in MongoDB; the in-memory cache hid the damage until the next restart, after which every read failed. `PlaceUrl` depends on these preferences, so URL construction — and with it every email — broke.

2. **Two `MustacheFactory` beans made `TemplateEngine` unusable** (#186). The engine resolves its factory through a lazy `Provider`, so the duplicate bean never failed startup — only the first real template render, with `NoUniqueBeanDefinitionException`.

Both were observed end to end on a fresh docker-compose deployment while testing #177.

## Changes

- `ApplicationPreferences.id` is no longer `final`, so Spring Data can populate it when reading a document back.
- On a read miss, `ApplicationPreferencesStore` now persists the complete defaults document instead of an empty upsert.
- The duplicate `MustacheFactory` bean is removed.

## Tests

- `ApplicationPreferencesStore_IT` reads through a **fresh store instance** (no in-memory cache) after both the miss path and an explicit save — the scenario the existing single-instance test couldn't catch because the cache masked the broken reads.
- `TemplateEngine_IT` renders a template through the application context, pinning that the lazy provider resolves to exactly one factory.

Full suite: 1,837 tests passing.