### PR TITLE
Update sharing invitation email copy for clarity

### DIFF
--- a/src/main/resources/templates/sharing-invitation-email-template.html
+++ b/src/main/resources/templates/sharing-invitation-email-template.html
@@ -21,13 +21,19 @@
 <body>
 <div class="main">
     <div>
-        <span class="inviter">{{inviter}}</span> has invited you to collaborate on the project <span class="projectName">{{project.displayName}}</span> in WebProtege.
+        You have been invited by <span class="inviter">{{inviter}}</span> to collaborate on the <span class="projectName">{{project.displayName}}</span> project in WebProtégé.
     </div>
     <div>
-        Create an account in <a href="{{{application.url}}}">WebProtege</a> to accept the invitation and start collaborating.
+        To accept this invitation and begin collaborating, create a WebProtégé account using this email address.
+    </div>
+    <div>
+        <a href="{{{application.url}}}">Create your WebProtégé account</a>
+    </div>
+    <div>
+        You will be able to access the project once your account has been created.
     </div>
     <div class="footer">
-        You received this email because someone invited you to a project on <a href="{{{application.url}}}">WebProtege</a>.
+        If you were not expecting this invitation, you can ignore this email.
     </div>
 </div>
 </body></html>


### PR DESCRIPTION
## Summary
- Rewords the sharing invitation email to explain plainly that the recipient should create a WebProtégé account using the invited email address, and what happens after.

## Test plan
- [x] Trigger a sharing invitation and review the rendered email template