### PR TITLE
Announce changes through a durable outbox instead of fire-and-forget dispatch

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/ProjectBeansConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ProjectBeansConfiguration.java
@@ -38,6 +38,9 @@ import edu.stanford.protege.webprotege.entity.EntityRenamer;
 import edu.stanford.protege.webprotege.entity.MergeEntitiesChangeListGeneratorFactory;
 import edu.stanford.protege.webprotege.entity.SubjectClosureResolver;
 import edu.stanford.protege.webprotege.events.*;
+import edu.stanford.protege.webprotege.events.outbox.DurableRevisionWatermark;
+import edu.stanford.protege.webprotege.events.outbox.DurableRevisionWatermarkRegistry;
+import edu.stanford.protege.webprotege.events.outbox.EventOutbox;
 import edu.stanford.protege.webprotege.filemanager.FileContents;
 import edu.stanford.protege.webprotege.forms.*;
 import edu.stanford.protege.webprotege.frame.*;
@@ -467,9 +470,19 @@ public class ProjectBeansConfiguration {
     public RevisionStoreImpl revisionStore(ProjectId p1,
                                            ChangeHistoryFileFactory p2,
                                            OWLDataFactory p3,
-                                           OntologyChangeRecordTranslator p4) {
+                                           OntologyChangeRecordTranslator p4,
+                                           DurableRevisionWatermarkRegistry durableRevisionWatermarkRegistry,
+                                           ProjectDisposablesManager projectDisposablesManager) {
         var revisionStore = new RevisionStoreImpl(p1, p2, p3, p4);
         revisionStore.load();
+        // Gate outbox publishing on durability.  Initialise the per-project durable-revision watermark to the
+        // head revision on disk (every loaded revision is durable) and advance it whenever the revision store
+        // reports that a change-history write has completed.  Registering the watermark lets the
+        // application-level relay promote this project's gated rows once their revision is durable.
+        var watermark = new DurableRevisionWatermark(p1, revisionStore.getCurrentRevisionNumber().getValue());
+        durableRevisionWatermarkRegistry.register(watermark);
+        revisionStore.setSavedHook(watermark::advance);
+        projectDisposablesManager.register(() -> durableRevisionWatermarkRegistry.deregister(p1));
         return revisionStore;
     }
 
@@ -620,7 +633,7 @@ public class ProjectBeansConfiguration {
                                 IndexUpdater p23,
                                 DefaultOntologyIdManager p24,
                                 IriReplacerFactory p25,
-                                GeneratedAnnotationsGenerator p26, EventDispatcher eventDispatcher, HierarchyProviderManager p27) {
+                                GeneratedAnnotationsGenerator p26, EventOutbox eventOutbox, HierarchyProviderManager p27) {
         return new ChangeManager(p1,
                                  p2,
                                  p3,
@@ -644,7 +657,7 @@ public class ProjectBeansConfiguration {
                                  p23,
                                  p24,
                                  p25,
-                                 p26, eventDispatcher, p27);
+                                 p26, eventOutbox, p27);
     }
 
 

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/DurableRevisionWatermark.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/DurableRevisionWatermark.java
@@ -1,0 +1,48 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import edu.stanford.protege.webprotege.common.ProjectId;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Tracks, per project, the highest revision number whose change-history write is known to be durable.
+ *
+ * <p>The watermark is a counter initialised to the head revision number when the revision store is loaded
+ * (every loaded revision is on disk and therefore durable) and incremented once for each subsequent durable
+ * write.  This is safe because the revision store persists changes on a single-threaded FIFO executor, so
+ * revision <i>N</i> becoming durable implies every revision {@code <= N} is durable.  The saved-hook that
+ * drives {@link #advance()} carries no revision number, which is why counting invocations is sufficient.</p>
+ */
+public class DurableRevisionWatermark {
+
+    private final ProjectId projectId;
+
+    private final AtomicLong durableRevision;
+
+    public DurableRevisionWatermark(@Nonnull ProjectId projectId, long headRevisionAtLoad) {
+        this.projectId = checkNotNull(projectId);
+        this.durableRevision = new AtomicLong(headRevisionAtLoad);
+    }
+
+    @Nonnull
+    public ProjectId getProjectId() {
+        return projectId;
+    }
+
+    /**
+     * Advances the watermark by one durable revision.  Invoked from the revision store's saved-hook.
+     */
+    public void advance() {
+        durableRevision.incrementAndGet();
+    }
+
+    /**
+     * Gets the highest revision number currently known to be durable.
+     */
+    public long getDurableRevision() {
+        return durableRevision.get();
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/DurableRevisionWatermarkRegistry.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/DurableRevisionWatermarkRegistry.java
@@ -1,0 +1,43 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import edu.stanford.protege.webprotege.common.ProjectId;
+
+import javax.annotation.Nonnull;
+import java.util.OptionalLong;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * An application-wide registry of the per-project {@link DurableRevisionWatermark}s.  Each project's watermark
+ * lives in the project's Spring context and registers itself here so that the application-level
+ * {@link EventOutboxRelay} can consult it when deciding whether gated rows may be published.
+ *
+ * <p>A project's watermark is only present in the instance that has the project loaded.  Under the
+ * single-homed-project assumption that is the only instance that writes that project's outbox rows, so the
+ * relay finds the watermark it needs.</p>
+ */
+public class DurableRevisionWatermarkRegistry {
+
+    private final ConcurrentMap<ProjectId, DurableRevisionWatermark> watermarks = new ConcurrentHashMap<>();
+
+    public void register(@Nonnull DurableRevisionWatermark watermark) {
+        checkNotNull(watermark);
+        watermarks.put(watermark.getProjectId(), watermark);
+    }
+
+    public void deregister(@Nonnull ProjectId projectId) {
+        watermarks.remove(checkNotNull(projectId));
+    }
+
+    /**
+     * Gets the highest durable revision for the given project, or empty if this instance does not have the
+     * project loaded (and therefore cannot vouch for the durability of its gated rows).
+     */
+    @Nonnull
+    public OptionalLong getDurableRevision(@Nonnull ProjectId projectId) {
+        var watermark = watermarks.get(checkNotNull(projectId));
+        return watermark == null ? OptionalLong.empty() : OptionalLong.of(watermark.getDurableRevision());
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutbox.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutbox.java
@@ -1,0 +1,76 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.stanford.protege.webprotege.project.PackagedProjectChangeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import jakarta.inject.Inject;
+import java.time.Clock;
+import java.util.OptionalLong;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Synchronously records project change events in the durable outbox in place of dispatching them directly.
+ * A revision-bearing event is written in the {@link EventOutboxState#GATED} state so that it cannot be
+ * published before its change-history write is durable; the {@link EventOutboxRelay} publishes it once the
+ * project's durable-revision watermark reaches the row's revision number.
+ */
+public class EventOutbox {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventOutbox.class);
+
+    private final EventOutboxRepository repository;
+
+    private final ObjectMapper objectMapper;
+
+    private final Clock clock;
+
+    @Inject
+    public EventOutbox(@Nonnull EventOutboxRepository repository,
+                       @Nonnull ObjectMapper objectMapper,
+                       @Nonnull Clock clock) {
+        this.repository = checkNotNull(repository);
+        this.objectMapper = checkNotNull(objectMapper);
+        this.clock = checkNotNull(clock);
+    }
+
+    /**
+     * Records a project change event for reliable delivery.
+     *
+     * @param event          the event to deliver.
+     * @param revisionNumber the revision number the event announces, if the change is revision-bearing.  When
+     *                       present the row is gated on durability; when absent it is immediately publishable.
+     * @throws EventOutboxException if the event cannot be serialized or persisted; the caller must let this
+     *                              propagate so that the change fails loudly rather than being silently lost.
+     */
+    public void enqueue(@Nonnull PackagedProjectChangeEvent event, @Nonnull OptionalLong revisionNumber) {
+        checkNotNull(event);
+        var state = revisionNumber.isPresent() ? EventOutboxState.GATED : EventOutboxState.PENDING;
+        var payload = serialize(event);
+        var record = EventOutboxRecord.create(event.projectId().value(),
+                                              revisionNumber.orElse(0L),
+                                              event.getChannel(),
+                                              payload,
+                                              state,
+                                              clock.instant());
+        try {
+            repository.insert(record);
+        } catch (RuntimeException e) {
+            throw new EventOutboxException("Could not write project change event to the outbox: " + event, e);
+        }
+        logger.info("[EventOutbox] Enqueued {} for project {} as {} (revision {})",
+                    event.getChannel(), event.projectId().value(), state, revisionNumber.isPresent() ? revisionNumber.getAsLong() : "n/a");
+    }
+
+    private String serialize(PackagedProjectChangeEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            throw new EventOutboxException("Could not serialize project change event: " + event, e);
+        }
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxConfiguration.java
@@ -1,0 +1,72 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.Clock;
+
+/**
+ * Wiring for the durable event outbox and its retrying relay.  {@link EnableScheduling} is switched on here
+ * (the application does not otherwise enable scheduling) so that {@link EventOutboxRelay#drainOutbox()} runs
+ * on a fixed delay.
+ */
+@Configuration
+@EnableScheduling
+public class EventOutboxConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    Clock outboxClock() {
+        return Clock.systemUTC();
+    }
+
+    @Bean
+    EventOutboxRepository eventOutboxRepository(MongoTemplate mongoTemplate) {
+        return new EventOutboxRepositoryImpl(mongoTemplate);
+    }
+
+    @Bean
+    DurableRevisionWatermarkRegistry durableRevisionWatermarkRegistry() {
+        return new DurableRevisionWatermarkRegistry();
+    }
+
+    @Bean
+    EventOutbox eventOutbox(EventOutboxRepository eventOutboxRepository,
+                            ObjectMapper objectMapper,
+                            Clock outboxClock) {
+        return new EventOutbox(eventOutboxRepository, objectMapper, outboxClock);
+    }
+
+    @Bean
+    EventOutboxRelay eventOutboxRelay(EventOutboxRepository eventOutboxRepository,
+                                      @Qualifier("eventRabbitTemplate") RabbitTemplate eventRabbitTemplate,
+                                      DurableRevisionWatermarkRegistry durableRevisionWatermarkRegistry,
+                                      @Value("${spring.application.name}") String applicationName,
+                                      Clock outboxClock,
+                                      @Value("${webprotege.events.outbox.base-backoff-ms:1000}") long baseBackoffMillis,
+                                      @Value("${webprotege.events.outbox.max-backoff-ms:60000}") long maxBackoffMillis,
+                                      @Value("${webprotege.events.outbox.oldest-pending-warn-ms:30000}") long oldestPendingWarnThresholdMillis) {
+        return new EventOutboxRelay(eventOutboxRepository,
+                                    eventRabbitTemplate,
+                                    durableRevisionWatermarkRegistry,
+                                    applicationName,
+                                    outboxClock,
+                                    baseBackoffMillis,
+                                    maxBackoffMillis,
+                                    oldestPendingWarnThresholdMillis);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "webprotege.events.outbox", name = "relay-enabled", matchIfMissing = true)
+    EventOutboxRelayScheduler eventOutboxRelayScheduler(EventOutboxRelay eventOutboxRelay) {
+        return new EventOutboxRelayScheduler(eventOutboxRelay);
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxException.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxException.java
@@ -1,0 +1,12 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+/**
+ * Thrown when a project change event cannot be written to the durable outbox.  Propagating this failure
+ * ensures a change is never recorded without an outbox row that will eventually announce it.
+ */
+public class EventOutboxException extends RuntimeException {
+
+    public EventOutboxException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRecord.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRecord.java
@@ -1,0 +1,149 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceCreator;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A durable record of a project change event that must be published to other services.  Rows are drained
+ * per project in insertion order (natural {@code _id} order) by {@link EventOutboxRelay}.
+ */
+@Document(collection = EventOutboxRecord.COLLECTION)
+@CompoundIndexes({
+        @CompoundIndex(name = "projectId_state", def = "{'projectId': 1, 'state': 1, '_id': 1}")
+})
+public class EventOutboxRecord {
+
+    public static final String COLLECTION = "EventOutbox";
+
+    public static final String PROJECT_ID = "projectId";
+
+    public static final String REVISION_NUMBER = "revisionNumber";
+
+    public static final String STATE = "state";
+
+    public static final String ATTEMPTS = "attempts";
+
+    public static final String LAST_ATTEMPT_AT = "lastAttemptAt";
+
+    public static final String CREATED_AT = "createdAt";
+
+    @Id
+    private final ObjectId id;
+
+    private final String projectId;
+
+    private final long revisionNumber;
+
+    private final String channel;
+
+    private final String payload;
+
+    private final EventOutboxState state;
+
+    private final int attempts;
+
+    @Nullable
+    private final Instant lastAttemptAt;
+
+    private final Instant createdAt;
+
+    @PersistenceCreator
+    public EventOutboxRecord(@Nullable ObjectId id,
+                             @Nonnull String projectId,
+                             long revisionNumber,
+                             @Nonnull String channel,
+                             @Nonnull String payload,
+                             @Nonnull EventOutboxState state,
+                             int attempts,
+                             @Nullable Instant lastAttemptAt,
+                             @Nonnull Instant createdAt) {
+        this.id = id;
+        this.projectId = checkNotNull(projectId);
+        this.revisionNumber = revisionNumber;
+        this.channel = checkNotNull(channel);
+        this.payload = checkNotNull(payload);
+        this.state = checkNotNull(state);
+        this.attempts = attempts;
+        this.lastAttemptAt = lastAttemptAt;
+        this.createdAt = checkNotNull(createdAt);
+    }
+
+    /**
+     * Creates a fresh record to be inserted.  The {@code _id} is left {@code null} so that Mongo mints a
+     * monotonically increasing {@link ObjectId} at insert time, which establishes the per-project ordering.
+     */
+    public static EventOutboxRecord create(@Nonnull String projectId,
+                                           long revisionNumber,
+                                           @Nonnull String channel,
+                                           @Nonnull String payload,
+                                           @Nonnull EventOutboxState state,
+                                           @Nonnull Instant createdAt) {
+        return new EventOutboxRecord(null, projectId, revisionNumber, channel, payload, state, 0, null, createdAt);
+    }
+
+    @Nullable
+    public ObjectId getId() {
+        return id;
+    }
+
+    @Nonnull
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public long getRevisionNumber() {
+        return revisionNumber;
+    }
+
+    @Nonnull
+    public String getChannel() {
+        return channel;
+    }
+
+    @Nonnull
+    public String getPayload() {
+        return payload;
+    }
+
+    @Nonnull
+    public EventOutboxState getState() {
+        return state;
+    }
+
+    public int getAttempts() {
+        return attempts;
+    }
+
+    @Nullable
+    public Instant getLastAttemptAt() {
+        return lastAttemptAt;
+    }
+
+    @Nonnull
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper("EventOutboxRecord")
+                .add("id", id)
+                .add("projectId", projectId)
+                .add("revisionNumber", revisionNumber)
+                .add("channel", channel)
+                .add("state", state)
+                .add("attempts", attempts)
+                .toString();
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRelay.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRelay.java
@@ -1,0 +1,158 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.ipc.Headers;
+import edu.stanford.protege.webprotege.ipc.impl.RabbitMQEventsConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Drains the durable {@link EventOutboxRecord} rows, publishing each to the event exchange.
+ *
+ * <p>The row stores the exact bytes that were serialized when the change was applied; the relay republishes
+ * those bytes with the same headers {@code RabbitMQEventDispatcher} sets, so the message on the wire is
+ * identical to a direct dispatch.  (Republishing the stored bytes rather than deserializing and re-dispatching
+ * is deliberate: the backend's ObjectMapper does not register the polymorphic {@code ProjectEvent} subtypes,
+ * so it can serialize a {@code PackagedProjectChangeEvent} but cannot deserialize one back.)</p>
+ *
+ * <p>Records for a project are processed strictly in insertion order.  Processing of a project stops at the
+ * first record that is still {@link EventOutboxState#GATED gated} on durability or that fails to publish, so a
+ * stall or a failure never lets a later change overtake an earlier one for the same project (head-of-line
+ * blocking preserves per-project ordering).  Delivery is at-least-once: a crash between a successful publish
+ * and the SENT write results in a re-publish, which downstream consumers de-duplicate.</p>
+ */
+public class EventOutboxRelay {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventOutboxRelay.class);
+
+    private final EventOutboxRepository repository;
+
+    private final RabbitTemplate eventRabbitTemplate;
+
+    private final DurableRevisionWatermarkRegistry watermarkRegistry;
+
+    private final String applicationName;
+
+    private final Clock clock;
+
+    private final long baseBackoffMillis;
+
+    private final long maxBackoffMillis;
+
+    private final long oldestPendingWarnThresholdMillis;
+
+    public EventOutboxRelay(@Nonnull EventOutboxRepository repository,
+                            @Nonnull RabbitTemplate eventRabbitTemplate,
+                            @Nonnull DurableRevisionWatermarkRegistry watermarkRegistry,
+                            @Nonnull String applicationName,
+                            @Nonnull Clock clock,
+                            long baseBackoffMillis,
+                            long maxBackoffMillis,
+                            long oldestPendingWarnThresholdMillis) {
+        this.repository = checkNotNull(repository);
+        this.eventRabbitTemplate = checkNotNull(eventRabbitTemplate);
+        this.watermarkRegistry = checkNotNull(watermarkRegistry);
+        this.applicationName = checkNotNull(applicationName);
+        this.clock = checkNotNull(clock);
+        this.baseBackoffMillis = baseBackoffMillis;
+        this.maxBackoffMillis = maxBackoffMillis;
+        this.oldestPendingWarnThresholdMillis = oldestPendingWarnThresholdMillis;
+    }
+
+    public void drainOutbox() {
+        for (var projectId : repository.findProjectIdsWithUnsentRecords()) {
+            try {
+                drainProject(ProjectId.valueOf(projectId));
+            } catch (RuntimeException e) {
+                // Isolate projects from one another: a failure draining one project must not prevent the
+                // others from being drained on this cycle.
+                logger.error("[EventOutboxRelay] Error draining outbox for project {}", projectId, e);
+            }
+        }
+        reportOldestUnsentAge();
+    }
+
+    private void drainProject(ProjectId projectId) {
+        watermarkRegistry.getDurableRevision(projectId)
+                .ifPresent(durableRevision -> repository.promoteGatedRecordsUpToRevision(projectId.value(), durableRevision));
+
+        for (var record : repository.findUnsentRecordsForProjectInOrder(projectId.value())) {
+            if (record.getState() == EventOutboxState.GATED) {
+                // The change-history write is not yet durable; nothing after it may be published either.
+                break;
+            }
+            if (isBackingOff(record)) {
+                break;
+            }
+            if (!publish(record)) {
+                // Leave this record PENDING and stop; do not publish later rows for this project.
+                break;
+            }
+        }
+    }
+
+    private boolean publish(EventOutboxRecord record) {
+        try {
+            eventRabbitTemplate.send(RabbitMQEventsConfiguration.EVENT_EXCHANGE, "", toMessage(record));
+        } catch (RuntimeException e) {
+            logger.warn("[EventOutboxRelay] Failed to publish outbox record {} for project {} (attempt {}); will retry",
+                        record.getId(), record.getProjectId(), record.getAttempts() + 1, e);
+            repository.recordFailedAttempt(record.getId(), clock.instant());
+            return false;
+        }
+        repository.markSent(record.getId());
+        return true;
+    }
+
+    private Message toMessage(EventOutboxRecord record) {
+        var message = MessageBuilder.withBody(record.getPayload().getBytes(StandardCharsets.UTF_8)).build();
+        var headers = message.getMessageProperties().getHeaders();
+        // The outbox only holds PackagedProjectChangeEvents, whose @JsonTypeName equals its channel, so the
+        // channel serves as both the event-type and channel headers, matching RabbitMQEventDispatcher.
+        headers.put(Headers.EVENT_TYPE, record.getChannel());
+        headers.put(Headers.CHANNEL, record.getChannel());
+        headers.put(Headers.PROJECT_ID, record.getProjectId());
+        message.getMessageProperties().setHeader(Headers.SERVICE_NAME, applicationName);
+        return message;
+    }
+
+    private boolean isBackingOff(EventOutboxRecord record) {
+        var lastAttemptAt = record.getLastAttemptAt();
+        if (record.getAttempts() == 0 || lastAttemptAt == null) {
+            return false;
+        }
+        var backoff = backoffFor(record.getAttempts());
+        return clock.instant().isBefore(lastAttemptAt.plusMillis(backoff));
+    }
+
+    private long backoffFor(int attempts) {
+        int shift = Math.min(attempts - 1, 16);
+        long backoff = baseBackoffMillis << shift;
+        if (backoff <= 0 || backoff > maxBackoffMillis) {
+            return maxBackoffMillis;
+        }
+        return backoff;
+    }
+
+    private void reportOldestUnsentAge() {
+        repository.findOldestUnsentRecordCreationTime().ifPresent(oldest -> {
+            var age = Duration.between(oldest, Instant.now(clock));
+            if (age.toMillis() >= oldestPendingWarnThresholdMillis) {
+                logger.warn("[EventOutboxRelay] Oldest unsent outbox record is {} ms old — the relay may be stalled", age.toMillis());
+            } else {
+                logger.debug("[EventOutboxRelay] Oldest unsent outbox record is {} ms old", age.toMillis());
+            }
+        });
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRelayScheduler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRelayScheduler.java
@@ -1,0 +1,26 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+import javax.annotation.Nonnull;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Drives {@link EventOutboxRelay#drainOutbox()} on a fixed delay.  Kept separate from the relay so that the
+ * relay's logic can be driven explicitly (in tests) without the background schedule; the schedule itself can
+ * be switched off with {@code webprotege.events.outbox.relay-enabled=false}.
+ */
+public class EventOutboxRelayScheduler {
+
+    private final EventOutboxRelay relay;
+
+    public EventOutboxRelayScheduler(@Nonnull EventOutboxRelay relay) {
+        this.relay = checkNotNull(relay);
+    }
+
+    @Scheduled(fixedDelayString = "${webprotege.events.outbox.relay-interval-ms:1000}")
+    public void run() {
+        relay.drainOutbox();
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRepository.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRepository.java
@@ -1,0 +1,58 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import org.bson.types.ObjectId;
+
+import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Persistence operations for the durable event outbox.
+ */
+public interface EventOutboxRepository {
+
+    /**
+     * Inserts a new outbox record.  Failures propagate so that a change can never be recorded without its
+     * corresponding outbox row.
+     */
+    void insert(@Nonnull EventOutboxRecord record);
+
+    /**
+     * Gets the ids of all projects that have at least one record that has not yet been sent (i.e. a record
+     * in the {@link EventOutboxState#GATED} or {@link EventOutboxState#PENDING} state).
+     */
+    @Nonnull
+    List<String> findProjectIdsWithUnsentRecords();
+
+    /**
+     * Gets the not-yet-sent records for a project in insertion (natural {@code _id}) order.
+     */
+    @Nonnull
+    List<EventOutboxRecord> findUnsentRecordsForProjectInOrder(@Nonnull String projectId);
+
+    /**
+     * Promotes {@link EventOutboxState#GATED} records for a project whose revision number is less than or
+     * equal to the supplied durable-revision watermark to {@link EventOutboxState#PENDING}.
+     *
+     * @return the number of records promoted.
+     */
+    long promoteGatedRecordsUpToRevision(@Nonnull String projectId, long durableRevision);
+
+    /**
+     * Marks a record as {@link EventOutboxState#SENT}.
+     */
+    void markSent(@Nonnull ObjectId id);
+
+    /**
+     * Records a failed publish attempt, incrementing the attempt count and stamping the attempt time.
+     */
+    void recordFailedAttempt(@Nonnull ObjectId id, @Nonnull Instant attemptedAt);
+
+    /**
+     * Gets the creation time of the oldest record still awaiting publication ({@link EventOutboxState#PENDING}
+     * or {@link EventOutboxState#GATED}), for liveness monitoring.
+     */
+    @Nonnull
+    Optional<Instant> findOldestUnsentRecordCreationTime();
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRepositoryImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRepositoryImpl.java
@@ -1,0 +1,80 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import javax.annotation.Nonnull;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static edu.stanford.protege.webprotege.events.outbox.EventOutboxRecord.*;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+public class EventOutboxRepositoryImpl implements EventOutboxRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Inject
+    public EventOutboxRepositoryImpl(@Nonnull MongoTemplate mongoTemplate) {
+        this.mongoTemplate = checkNotNull(mongoTemplate);
+    }
+
+    @Override
+    public void insert(@Nonnull EventOutboxRecord record) {
+        mongoTemplate.insert(checkNotNull(record));
+    }
+
+    @Nonnull
+    @Override
+    public List<String> findProjectIdsWithUnsentRecords() {
+        var query = query(where(STATE).in(EventOutboxState.GATED, EventOutboxState.PENDING));
+        return mongoTemplate.findDistinct(query, PROJECT_ID, EventOutboxRecord.class, String.class);
+    }
+
+    @Nonnull
+    @Override
+    public List<EventOutboxRecord> findUnsentRecordsForProjectInOrder(@Nonnull String projectId) {
+        var query = query(where(PROJECT_ID).is(projectId)
+                                  .and(STATE).in(EventOutboxState.GATED, EventOutboxState.PENDING))
+                .with(Sort.by(Sort.Direction.ASC, "_id"));
+        return mongoTemplate.find(query, EventOutboxRecord.class);
+    }
+
+    @Override
+    public long promoteGatedRecordsUpToRevision(@Nonnull String projectId, long durableRevision) {
+        var query = query(where(PROJECT_ID).is(projectId)
+                                  .and(STATE).is(EventOutboxState.GATED)
+                                  .and(REVISION_NUMBER).lte(durableRevision));
+        var update = new Update().set(STATE, EventOutboxState.PENDING);
+        return mongoTemplate.updateMulti(query, update, EventOutboxRecord.class).getModifiedCount();
+    }
+
+    @Override
+    public void markSent(@Nonnull ObjectId id) {
+        var update = new Update().set(STATE, EventOutboxState.SENT);
+        mongoTemplate.updateFirst(query(where("_id").is(id)), update, EventOutboxRecord.class);
+    }
+
+    @Override
+    public void recordFailedAttempt(@Nonnull ObjectId id, @Nonnull Instant attemptedAt) {
+        var update = new Update().inc(ATTEMPTS, 1).set(LAST_ATTEMPT_AT, attemptedAt);
+        mongoTemplate.updateFirst(query(where("_id").is(id)), update, EventOutboxRecord.class);
+    }
+
+    @Nonnull
+    @Override
+    public Optional<Instant> findOldestUnsentRecordCreationTime() {
+        var query = query(where(STATE).in(EventOutboxState.GATED, EventOutboxState.PENDING))
+                .with(Sort.by(Sort.Direction.ASC, CREATED_AT))
+                .limit(1);
+        var record = mongoTemplate.findOne(query, EventOutboxRecord.class);
+        return Optional.ofNullable(record).map(EventOutboxRecord::getCreatedAt);
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxState.java
+++ b/src/main/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxState.java
@@ -1,0 +1,24 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+/**
+ * The lifecycle state of an {@link EventOutboxRecord}.
+ */
+public enum EventOutboxState {
+
+    /**
+     * The row belongs to a revision-bearing change whose change-history write is not yet known to be
+     * durable.  It must not be published until the project's durable-revision watermark reaches the
+     * row's revision number.
+     */
+    GATED,
+
+    /**
+     * The row is ready to be published and is awaiting the relay.
+     */
+    PENDING,
+
+    /**
+     * The row has been handed to the event dispatcher successfully.
+     */
+    SENT
+}

--- a/src/main/java/edu/stanford/protege/webprotege/project/chg/ChangeManager.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/chg/ChangeManager.java
@@ -14,11 +14,11 @@ import edu.stanford.protege.webprotege.entity.FreshEntityIri;
 import edu.stanford.protege.webprotege.events.EventTranslatorManager;
 import edu.stanford.protege.webprotege.events.EventTranslatorSessionId;
 import edu.stanford.protege.webprotege.events.HighLevelProjectEventProxy;
+import edu.stanford.protege.webprotege.events.outbox.EventOutbox;
 import edu.stanford.protege.webprotege.hierarchy.*;
 import edu.stanford.protege.webprotege.index.RootIndex;
 import edu.stanford.protege.webprotege.index.impl.IndexUpdater;
 import edu.stanford.protege.webprotege.inject.ProjectSingleton;
-import edu.stanford.protege.webprotege.ipc.EventDispatcher;
 import edu.stanford.protege.webprotege.lang.ActiveLanguagesManager;
 import edu.stanford.protege.webprotege.owlapi.OWLEntityCreator;
 import edu.stanford.protege.webprotege.owlapi.RenameMap;
@@ -84,7 +84,7 @@ public class ChangeManager implements HasApplyChanges {
     private final ProjectChangedWebhookInvoker projectChangedWebhookInvoker;
 
     @Nonnull
-    private final EventDispatcher eventDispatcher;
+    private final EventOutbox eventOutbox;
 
     @Nonnull
     private final Provider<EventTranslatorManager> eventTranslatorManagerProvider;
@@ -160,7 +160,7 @@ public class ChangeManager implements HasApplyChanges {
                          @Nonnull DefaultOntologyIdManager defaultOntologyIdManager,
                          @Nonnull IriReplacerFactory iriReplacerFactory,
                          @Nonnull GeneratedAnnotationsGenerator generatedAnnotationsGenerator,
-                         @Nonnull EventDispatcher eventDispatcher, HierarchyProviderManager hierarchyProviderManager) {
+                         @Nonnull EventOutbox eventOutbox, HierarchyProviderManager hierarchyProviderManager) {
         this.projectId = projectId;
         this.dataFactory = dataFactory;
         this.dictionaryUpdatesProcessor = dictionaryUpdatesProcessor;
@@ -171,7 +171,7 @@ public class ChangeManager implements HasApplyChanges {
         this.projectChangedWebhookInvoker = projectChangedWebhookInvoker;
         this.eventTranslatorManagerProvider = eventTranslatorManagerProvider;
         this.entityCrudKitHandlerCache = entityCrudKitHandlerCache;
-        this.eventDispatcher = eventDispatcher;
+        this.eventOutbox = eventOutbox;
         this.changeManager = changeManager;
         this.rootIndex = rootIndex;
         this.dictionaryManager = dictionaryManager;
@@ -529,7 +529,13 @@ public class ChangeManager implements HasApplyChanges {
         });
         if(!eventList.isEmpty()) {
             var packagedProjectChange = new PackagedProjectChangeEvent(projectId, EventId.generate(), eventList);
-            eventDispatcher.dispatchEvent(packagedProjectChange);
+            // Record the change event in the durable outbox instead of dispatching it directly.  A
+            // revision-bearing change is gated on the revision's change-history write becoming durable.  An
+            // insert failure propagates so that a change is never saved without a row that will announce it.
+            var revisionNumber = revision.isPresent()
+                    ? OptionalLong.of(revision.get().getRevisionNumber().getValue())
+                    : OptionalLong.empty();
+            eventOutbox.enqueue(packagedProjectChange, revisionNumber);
         }
     }
 

--- a/src/test/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxIntegration_IT.java
+++ b/src/test/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxIntegration_IT.java
@@ -1,0 +1,145 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import edu.stanford.protege.webprotege.MongoTestExtension;
+import edu.stanford.protege.webprotege.RabbitTestExtension;
+import edu.stanford.protege.webprotege.WebprotegeBackendMonolithApplication;
+import edu.stanford.protege.webprotege.common.EventId;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.event.BrowserTextChangedEvent;
+import edu.stanford.protege.webprotege.ipc.Headers;
+import edu.stanford.protege.webprotege.ipc.impl.RabbitMQEventsConfiguration;
+import edu.stanford.protege.webprotege.project.PackagedProjectChangeEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.FanoutExchange;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end tests for the outbox: a change event enqueued through {@link EventOutbox} is republished by the
+ * {@link EventOutboxRelay} to the real event exchange and marked sent, and a durability-gated event is held
+ * back until its project's watermark advances.
+ */
+@SpringBootTest
+@Import({WebprotegeBackendMonolithApplication.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@ExtendWith({SpringExtension.class, MongoTestExtension.class, RabbitTestExtension.class})
+@ActiveProfiles("test")
+public class EventOutboxIntegration_IT {
+
+    @Autowired
+    private EventOutbox eventOutbox;
+
+    @Autowired
+    private EventOutboxRepository repository;
+
+    @Autowired
+    private EventOutboxRelay relay;
+
+    @Autowired
+    private DurableRevisionWatermarkRegistry watermarkRegistry;
+
+    @Autowired
+    private OWLDataFactory dataFactory;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ConnectionFactory connectionFactory;
+
+    private RabbitTemplate rabbitTemplate;
+
+    private String queueName;
+
+    private ProjectId projectId;
+
+    @BeforeEach
+    void setUp(@Autowired MongoTemplate mongoTemplate) {
+        mongoTemplate.dropCollection(EventOutboxRecord.COLLECTION);
+        projectId = ProjectId.valueOf(UUID.randomUUID().toString());
+        rabbitTemplate = new RabbitTemplate(connectionFactory);
+
+        // Bind a private test queue to the fanout event exchange so we can observe what the relay publishes.
+        queueName = "test-outbox-" + UUID.randomUUID();
+        var admin = new RabbitAdmin(connectionFactory);
+        var exchange = new FanoutExchange(RabbitMQEventsConfiguration.EVENT_EXCHANGE, true, false);
+        admin.declareExchange(exchange);
+        var queue = new Queue(queueName, false, false, false);
+        admin.declareQueue(queue);
+        admin.declareBinding(BindingBuilder.bind(queue).to(exchange));
+    }
+
+    @AfterEach
+    void tearDown() {
+        watermarkRegistry.deregister(projectId);
+        new RabbitAdmin(connectionFactory).deleteQueue(queueName);
+    }
+
+    @Test
+    void shouldPublishPendingEventAndMarkItSent() throws Exception {
+        eventOutbox.enqueue(changeEvent(), OptionalLong.empty());
+
+        relay.drainOutbox();
+
+        var message = rabbitTemplate.receive(queueName, 5000);
+        assertNotNull(message, "the relay should have published the event to the exchange");
+        var headers = message.getMessageProperties().getHeaders();
+        assertEquals(projectId.value(), headers.get(Headers.PROJECT_ID));
+        assertEquals(PackagedProjectChangeEvent.CHANNEL, headers.get(Headers.CHANNEL));
+        var body = objectMapper.readTree(message.getBody());
+        assertTrue(body.get("projectEvents").isArray(), "the published body should carry the change events");
+        assertEquals(1, body.get("projectEvents").size());
+        assertTrue(repository.findUnsentRecordsForProjectInOrder(projectId.value()).isEmpty(),
+                   "the record should have been marked sent");
+    }
+
+    @Test
+    void shouldNotPublishGatedEventUntilTheWatermarkReachesItsRevision() throws Exception {
+        var watermark = new DurableRevisionWatermark(projectId, 0);
+        watermarkRegistry.register(watermark);
+        eventOutbox.enqueue(changeEvent(), OptionalLong.of(1));
+
+        // Watermark is behind the event's revision: nothing is published and the row stays gated.
+        relay.drainOutbox();
+        assertNull(rabbitTemplate.receive(queueName, 1000), "a gated event must not be published");
+        assertEquals(EventOutboxState.GATED,
+                     repository.findUnsentRecordsForProjectInOrder(projectId.value()).get(0).getState());
+
+        // The revision becomes durable: the row is promoted and published.
+        watermark.advance();
+        relay.drainOutbox();
+        assertNotNull(rabbitTemplate.receive(queueName, 5000), "the event should be published once durable");
+        assertTrue(repository.findUnsentRecordsForProjectInOrder(projectId.value()).isEmpty(),
+                   "the record should have been marked sent");
+    }
+
+    private PackagedProjectChangeEvent changeEvent() {
+        var entity = dataFactory.getOWLClass(IRI.create("http://example.org/A"));
+        var nested = new BrowserTextChangedEvent(EventId.generate(), projectId, entity, "A", ImmutableList.of());
+        return new PackagedProjectChangeEvent(projectId, EventId.generate(), List.of(nested));
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRelay_Test.java
+++ b/src/test/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRelay_Test.java
@@ -1,0 +1,203 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.ipc.impl.RabbitMQEventsConfiguration;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the relay's ordering, head-of-line blocking, durability gate and back-off behaviour.  The
+ * events template is a mock so that publish failures can be simulated deterministically.
+ */
+public class EventOutboxRelay_Test {
+
+    private static final String EXCHANGE = RabbitMQEventsConfiguration.EVENT_EXCHANGE;
+
+    private EventOutboxRepository repository;
+
+    private RabbitTemplate eventRabbitTemplate;
+
+    private DurableRevisionWatermarkRegistry watermarkRegistry;
+
+    private MutableClock clock;
+
+    private EventOutboxRelay relay;
+
+    private final ProjectId projectP = ProjectId.valueOf("11111111-1111-1111-1111-111111111111");
+
+    private final ProjectId projectQ = ProjectId.valueOf("22222222-2222-2222-2222-222222222222");
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(EventOutboxRepository.class);
+        eventRabbitTemplate = mock(RabbitTemplate.class);
+        watermarkRegistry = new DurableRevisionWatermarkRegistry();
+        clock = new MutableClock(Instant.parse("2026-07-24T00:00:00Z"));
+        relay = new EventOutboxRelay(repository, eventRabbitTemplate, watermarkRegistry, "backend", clock,
+                                     1000, 60000, 30000);
+        when(repository.findOldestUnsentRecordCreationTime()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void happyPath_publishesPendingRecordsInOrderAndMarksSent() {
+        var r1 = pending(projectP, "p1");
+        var r2 = pending(projectP, "p2");
+        when(repository.findProjectIdsWithUnsentRecords()).thenReturn(List.of(projectP.value()));
+        when(repository.findUnsentRecordsForProjectInOrder(projectP.value())).thenReturn(List.of(r1, r2));
+
+        relay.drainOutbox();
+
+        var inOrder = inOrder(eventRabbitTemplate, repository);
+        inOrder.verify(eventRabbitTemplate).send(eq(EXCHANGE), eq(""), argThat(bodyIs("p1")));
+        inOrder.verify(repository).markSent(r1.getId());
+        inOrder.verify(eventRabbitTemplate).send(eq(EXCHANGE), eq(""), argThat(bodyIs("p2")));
+        inOrder.verify(repository).markSent(r2.getId());
+        verify(repository, never()).recordFailedAttempt(any(), any());
+    }
+
+    @Test
+    void brokerDown_leavesRecordPendingAndRecordsFailedAttempt() {
+        var r1 = pending(projectP, "p1");
+        when(repository.findProjectIdsWithUnsentRecords()).thenReturn(List.of(projectP.value()));
+        when(repository.findUnsentRecordsForProjectInOrder(projectP.value())).thenReturn(List.of(r1));
+        doThrow(new AmqpException("broker down")).when(eventRabbitTemplate).send(eq(EXCHANGE), eq(""), any(Message.class));
+
+        relay.drainOutbox();
+
+        verify(repository).recordFailedAttempt(r1.getId(), clock.instant());
+        verify(repository, never()).markSent(any());
+    }
+
+    @Test
+    void headOfLineFailure_blocksLaterRecordsForSameProjectButNotOtherProjects() {
+        var r1 = pending(projectP, "p1");
+        var r2 = pending(projectP, "p2");
+        var q1 = pending(projectQ, "q1");
+        when(repository.findProjectIdsWithUnsentRecords()).thenReturn(List.of(projectP.value(), projectQ.value()));
+        when(repository.findUnsentRecordsForProjectInOrder(projectP.value())).thenReturn(List.of(r1, r2));
+        when(repository.findUnsentRecordsForProjectInOrder(projectQ.value())).thenReturn(List.of(q1));
+        doThrow(new AmqpException("broker down")).when(eventRabbitTemplate).send(eq(EXCHANGE), eq(""), argThat(bodyIs("p1")));
+
+        relay.drainOutbox();
+
+        // Project P blocks at r1; r2 is never published or marked sent.
+        verify(repository).recordFailedAttempt(r1.getId(), clock.instant());
+        verify(eventRabbitTemplate, never()).send(eq(EXCHANGE), eq(""), argThat(bodyIs("p2")));
+        verify(repository, never()).markSent(r2.getId());
+        // Project Q is unaffected.
+        verify(eventRabbitTemplate).send(eq(EXCHANGE), eq(""), argThat(bodyIs("q1")));
+        verify(repository).markSent(q1.getId());
+    }
+
+    @Test
+    void gatedRecord_isNotPublishedAndBlocksLaterRecords() {
+        var gated = gated(projectP, 5, "g1");
+        var later = pending(projectP, "p2");
+        when(repository.findProjectIdsWithUnsentRecords()).thenReturn(List.of(projectP.value()));
+        when(repository.findUnsentRecordsForProjectInOrder(projectP.value())).thenReturn(List.of(gated, later));
+
+        relay.drainOutbox();
+
+        verify(eventRabbitTemplate, never()).send(anyString(), anyString(), any(Message.class));
+        verify(repository, never()).markSent(any());
+    }
+
+    @Test
+    void relay_promotesGatedRecordsUpToTheProjectWatermark() {
+        watermarkRegistry.register(new DurableRevisionWatermark(projectP, 7));
+        when(repository.findProjectIdsWithUnsentRecords()).thenReturn(List.of(projectP.value()));
+        when(repository.findUnsentRecordsForProjectInOrder(projectP.value())).thenReturn(emptyList());
+
+        relay.drainOutbox();
+
+        verify(repository).promoteGatedRecordsUpToRevision(projectP.value(), 7);
+    }
+
+    @Test
+    void relay_doesNotPromoteGatedRecordsForProjectsWithoutAWatermark() {
+        when(repository.findProjectIdsWithUnsentRecords()).thenReturn(List.of(projectP.value()));
+        when(repository.findUnsentRecordsForProjectInOrder(projectP.value())).thenReturn(emptyList());
+
+        relay.drainOutbox();
+
+        verify(repository, never()).promoteGatedRecordsUpToRevision(anyString(), anyLong());
+    }
+
+    @Test
+    void backoff_skipsRecentlyFailedRecordUntilBackoffElapses() {
+        var failed = new EventOutboxRecord(new ObjectId(), projectP.value(), 0, "channel", "p1",
+                                           EventOutboxState.PENDING, 1, clock.instant(), clock.instant());
+        when(repository.findProjectIdsWithUnsentRecords()).thenReturn(List.of(projectP.value()));
+        when(repository.findUnsentRecordsForProjectInOrder(projectP.value())).thenReturn(List.of(failed));
+
+        // Within the back-off window (base 1000 ms for the first retry): nothing published.
+        clock.advanceMillis(500);
+        relay.drainOutbox();
+        verify(eventRabbitTemplate, never()).send(anyString(), anyString(), any(Message.class));
+
+        // After the back-off window elapses: the record is published.
+        clock.advanceMillis(1000);
+        relay.drainOutbox();
+        verify(eventRabbitTemplate).send(eq(EXCHANGE), eq(""), argThat(bodyIs("p1")));
+        verify(repository).markSent(failed.getId());
+    }
+
+    private EventOutboxRecord pending(ProjectId projectId, String payload) {
+        return new EventOutboxRecord(new ObjectId(), projectId.value(), 0, "channel", payload,
+                                     EventOutboxState.PENDING, 0, null, clock.instant());
+    }
+
+    private EventOutboxRecord gated(ProjectId projectId, long revision, String payload) {
+        return new EventOutboxRecord(new ObjectId(), projectId.value(), revision, "channel", payload,
+                                     EventOutboxState.GATED, 0, null, clock.instant());
+    }
+
+    private static ArgumentMatcher<Message> bodyIs(String expected) {
+        return message -> message != null && expected.equals(new String(message.getBody(), StandardCharsets.UTF_8));
+    }
+
+    private static final class MutableClock extends Clock {
+
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advanceMillis(long millis) {
+            this.instant = this.instant.plusMillis(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRepositoryImpl_IT.java
+++ b/src/test/java/edu/stanford/protege/webprotege/events/outbox/EventOutboxRepositoryImpl_IT.java
@@ -1,0 +1,128 @@
+package edu.stanford.protege.webprotege.events.outbox;
+
+import edu.stanford.protege.webprotege.MongoTestExtension;
+import edu.stanford.protege.webprotege.WebprotegeBackendMonolithApplication;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(classes = WebprotegeBackendMonolithApplication.class, properties = "webprotege.rabbitmq.commands-subscribe=false")
+@ExtendWith({MongoTestExtension.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+public class EventOutboxRepositoryImpl_IT {
+
+    @Autowired
+    private EventOutboxRepository repository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    private final Instant baseTime = Instant.parse("2026-07-24T00:00:00Z");
+
+    @AfterEach
+    void tearDown() {
+        mongoTemplate.dropCollection(EventOutboxRecord.COLLECTION);
+    }
+
+    @Test
+    void shouldReturnUnsentRecordsForProjectInInsertionOrder() {
+        var projectId = freshProjectId();
+        insert(projectId, 1, EventOutboxState.GATED, "first", baseTime);
+        insert(projectId, 2, EventOutboxState.GATED, "second", baseTime.plusSeconds(1));
+        insert(projectId, 3, EventOutboxState.PENDING, "third", baseTime.plusSeconds(2));
+
+        var payloadsInOrder = repository.findUnsentRecordsForProjectInOrder(projectId.value())
+                .stream().map(EventOutboxRecord::getPayload).collect(toList());
+
+        assertThat(payloadsInOrder, contains("first", "second", "third"));
+    }
+
+    @Test
+    void shouldExcludeSentRecordsFromUnsentQueries() {
+        var projectId = freshProjectId();
+        insert(projectId, 1, EventOutboxState.PENDING, "payload", baseTime);
+        var record = repository.findUnsentRecordsForProjectInOrder(projectId.value()).get(0);
+
+        repository.markSent(record.getId());
+
+        assertThat(repository.findUnsentRecordsForProjectInOrder(projectId.value()), is(empty()));
+        assertThat(repository.findProjectIdsWithUnsentRecords(), not(hasItem(projectId.value())));
+    }
+
+    @Test
+    void shouldPromoteOnlyGatedRecordsUpToTheWatermark() {
+        var projectId = freshProjectId();
+        insert(projectId, 1, EventOutboxState.GATED, "rev1", baseTime);
+        insert(projectId, 2, EventOutboxState.GATED, "rev2", baseTime.plusSeconds(1));
+        insert(projectId, 3, EventOutboxState.GATED, "rev3", baseTime.plusSeconds(2));
+
+        var promoted = repository.promoteGatedRecordsUpToRevision(projectId.value(), 2);
+
+        assertThat(promoted, is(2L));
+        var states = repository.findUnsentRecordsForProjectInOrder(projectId.value())
+                .stream().map(EventOutboxRecord::getState).collect(toList());
+        assertThat(states, contains(EventOutboxState.PENDING, EventOutboxState.PENDING, EventOutboxState.GATED));
+    }
+
+    @Test
+    void shouldRecordFailedAttempt() {
+        var projectId = freshProjectId();
+        insert(projectId, 1, EventOutboxState.PENDING, "payload", baseTime);
+        var record = repository.findUnsentRecordsForProjectInOrder(projectId.value()).get(0);
+        var attemptedAt = baseTime.plusSeconds(5);
+
+        repository.recordFailedAttempt(record.getId(), attemptedAt);
+
+        var updated = repository.findUnsentRecordsForProjectInOrder(projectId.value()).get(0);
+        assertThat(updated.getAttempts(), is(1));
+        assertThat(updated.getLastAttemptAt(), is(attemptedAt));
+    }
+
+    @Test
+    void shouldOnlyReportProjectsWithUnsentRecords() {
+        var withUnsent = freshProjectId();
+        var allSent = freshProjectId();
+        insert(withUnsent, 1, EventOutboxState.PENDING, "pending", baseTime);
+        insert(allSent, 1, EventOutboxState.PENDING, "willBeSent", baseTime);
+        var sentRecord = repository.findUnsentRecordsForProjectInOrder(allSent.value()).get(0);
+        repository.markSent(sentRecord.getId());
+
+        var projectIds = repository.findProjectIdsWithUnsentRecords();
+
+        assertThat(projectIds, hasItem(withUnsent.value()));
+        assertThat(projectIds, not(hasItem(allSent.value())));
+    }
+
+    @Test
+    void shouldReportTheOldestUnsentRecordCreationTime() {
+        var projectId = freshProjectId();
+        insert(projectId, 1, EventOutboxState.PENDING, "older", baseTime);
+        insert(projectId, 2, EventOutboxState.GATED, "newer", baseTime.plusSeconds(30));
+
+        var oldest = repository.findOldestUnsentRecordCreationTime();
+
+        assertThat(oldest.isPresent(), is(true));
+        assertThat(oldest.get(), is(baseTime));
+    }
+
+    private void insert(ProjectId projectId, long revision, EventOutboxState state, String payload, Instant createdAt) {
+        repository.insert(EventOutboxRecord.create(projectId.value(), revision, "channel", payload, state, createdAt));
+    }
+
+    private ProjectId freshProjectId() {
+        return ProjectId.valueOf(UUID.randomUUID().toString());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,6 +6,9 @@ webprotege.directories.data: /tmp/webprotege-test/data
 
 spring.data.mongodb.auto-index-creation: true
 
+# Tests drive the outbox relay explicitly; keep the background schedule off so it cannot race test assertions.
+webprotege.events.outbox.relay-enabled=false
+
 spring.main.allow-bean-definition-overriding=true
 
 webprotege.entityGraph.edgeLimit=3000


### PR DESCRIPTION
The backend half of protegeproject/webprotege-gwt-ui#299 (part of protegeproject/webprotege-gwt-ui#303).

Applying a change published its event to the broker fire-and-forget — a broker hiccup meant the change saved while every other viewer silently went stale. Now:
- The change site writes to a durable **EventOutbox** collection; an insert failure fails the request, so a change can never be saved-but-unannounceable.
- A scheduled **relay** drains per project in insertion order, marks rows SENT only after successful publish, backs off with per-project head-of-line blocking (ordering preserved), and logs oldest-unsent age. At-least-once; consumers dedupe by event id.
- **Durability gate:** revision-bearing rows start GATED and are released only when the revision store's saved-hook confirms the change-history write hit disk — no more announcing changes a crash could un-happen.

Review notes:
- The relay republishes the stored bytes with the dispatcher's headers rather than re-dispatching: this service's ObjectMapper cannot deserialize polymorphic project events (verified `InvalidTypeIdException`), and the wire message is byte-identical. Follow-up once the confirm-enabled ipc lands (protegeproject/webprotege-ipc#32): gate SENT on publisher confirms.
- Follow-ups filed in the epic notes: TTL/purge for SENT rows; startup cleanup of orphaned GATED rows; single-homed-project assumption (multi-instance would double-publish, harmless under at-least-once).
- Tests: 20/20 under JDK 17 (Testcontainers Mongo + Rabbit; broker-down, head-of-line, and watermark-gating scenarios all covered). Sibling fix: the event-history consumer's swallow (same ticket) rides with the #301 work there.